### PR TITLE
Fix missing logos in packaged desktop builds

### DIFF
--- a/docs/legal/THIRD_PARTY_NOTICES.txt
+++ b/docs/legal/THIRD_PARTY_NOTICES.txt
@@ -851,317 +851,317 @@ License text: not present in the installed package
 @rolldown/pluginutils 1.0.0-rc.7, 1.0.1
 License: MIT
 Homepage: https://github.com/rolldown/plugins/tree/main/packages/pluginutils#readme
-License text: 51
+License text: 51, 52
 
 @sindresorhus/is 4.6.0
 License: MIT
 Homepage: https://github.com/sindresorhus/is#readme
-License text: 52
+License text: 53
 
 @standard-schema/spec 1.1.0
 License: MIT
 Homepage: https://standardschema.dev
-License text: 53
+License text: 54
 
 @szmarczak/http-timer 4.0.6
 License: MIT
 Homepage: https://github.com/szmarczak/http-timer#readme
-License text: 54
+License text: 55
 
 @types/cacheable-request 6.0.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/cacheable-request
-License text: 55
+License text: 56
 
 @types/chai 5.2.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/chai
-License text: 55
+License text: 56
 
 @types/d3 7.4.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3
-License text: 55
+License text: 56
 
 @types/d3-array 3.2.2
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-array
-License text: 55
+License text: 56
 
 @types/d3-axis 3.0.6
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-axis
-License text: 55
+License text: 56
 
 @types/d3-brush 3.0.6
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-brush
-License text: 55
+License text: 56
 
 @types/d3-chord 3.0.6
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-chord
-License text: 55
+License text: 56
 
 @types/d3-color 3.1.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-color
-License text: 55
+License text: 56
 
 @types/d3-contour 3.0.6
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-contour
-License text: 55
+License text: 56
 
 @types/d3-delaunay 6.0.4
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-delaunay
-License text: 55
+License text: 56
 
 @types/d3-dispatch 3.0.7
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-dispatch
-License text: 55
+License text: 56
 
 @types/d3-drag 3.0.7
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-drag
-License text: 55
+License text: 56
 
 @types/d3-dsv 3.0.7
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-dsv
-License text: 55
+License text: 56
 
 @types/d3-ease 3.0.2
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-ease
-License text: 55
+License text: 56
 
 @types/d3-fetch 3.0.7
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-fetch
-License text: 55
+License text: 56
 
 @types/d3-force 3.0.10
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-force
-License text: 55
+License text: 56
 
 @types/d3-format 3.0.4
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-format
-License text: 55
+License text: 56
 
 @types/d3-geo 3.1.0
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-geo
-License text: 55
+License text: 56
 
 @types/d3-hierarchy 3.1.7
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-hierarchy
-License text: 55
+License text: 56
 
 @types/d3-interpolate 3.0.4
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-interpolate
-License text: 55
+License text: 56
 
 @types/d3-path 3.1.1
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-path
-License text: 55
+License text: 56
 
 @types/d3-polygon 3.0.2
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-polygon
-License text: 55
+License text: 56
 
 @types/d3-quadtree 3.0.6
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-quadtree
-License text: 55
+License text: 56
 
 @types/d3-random 3.0.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-random
-License text: 55
+License text: 56
 
 @types/d3-scale 4.0.9
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-scale
-License text: 55
+License text: 56
 
 @types/d3-scale-chromatic 3.1.0
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-scale-chromatic
-License text: 55
+License text: 56
 
 @types/d3-selection 3.0.11
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-selection
-License text: 55
+License text: 56
 
 @types/d3-shape 3.1.8
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-shape
-License text: 55
+License text: 56
 
 @types/d3-time 3.0.4
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-time
-License text: 55
+License text: 56
 
 @types/d3-time-format 4.0.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-time-format
-License text: 55
+License text: 56
 
 @types/d3-timer 3.0.2
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-timer
-License text: 55
+License text: 56
 
 @types/d3-transition 3.0.9
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-transition
-License text: 55
+License text: 56
 
 @types/d3-zoom 3.0.8
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/d3-zoom
-License text: 55
+License text: 56
 
 @types/debug 4.1.13
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/debug
-License text: 55
+License text: 56
 
 @types/deep-eql 4.0.2
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/deep-eql
-License text: 55
+License text: 56
 
 @types/estree 1.0.8
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/estree
-License text: 55
+License text: 56
 
 @types/fs-extra 9.0.13
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/fs-extra
-License text: 55
+License text: 56
 
 @types/geojson 7946.0.16
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/geojson
-License text: 55
+License text: 56
 
 @types/hammerjs 2.0.46
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/hammerjs
-License text: 55
+License text: 56
 
 @types/http-cache-semantics 4.2.0
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/http-cache-semantics
-License text: 55
+License text: 56
 
 @types/keyv 3.1.4
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/keyv
-License text: 55
+License text: 56
 
 @types/lodash 4.17.24
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/lodash
-License text: 55
+License text: 56
 
 @types/lodash-es 4.17.12
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/lodash-es
-License text: 55
+License text: 56
 
 @types/ms 2.1.0
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ms
-License text: 55
+License text: 56
 
 @types/node 22.20.1, 24.13.3, 25.9.3, 26.1.1
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
-License text: 55
+License text: 56
 
 @types/react 19.2.14
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react
-License text: 55
+License text: 56
 
 @types/react-dom 19.2.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom
-License text: 55
+License text: 56
 
 @types/responselike 1.0.3
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/responselike
-License text: 55
+License text: 56
 
 @types/scroller 0.1.5
 License: MIT
 Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scroller
-License text: 55
+License text: 56
 
 @typescript-eslint/eslint-plugin 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io/packages/eslint-plugin
-License text: 56
+License text: 57
 
 @typescript-eslint/parser 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io/packages/parser
-License text: 56
+License text: 57
 
 @typescript-eslint/project-service 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io
-License text: 57
+License text: 58
 
 @typescript-eslint/scope-manager 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io/packages/scope-manager
-License text: 56
+License text: 57
 
 @typescript-eslint/tsconfig-utils 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io
-License text: 57
+License text: 58
 
 @typescript-eslint/type-utils 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io
-License text: 58
+License text: 59
 
 @typescript-eslint/types 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io
-License text: 56
+License text: 57
 
 @typescript-eslint/typescript-estree 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io/packages/typescript-estree
-License text: 56
+License text: 57
 
 @typescript-eslint/utils 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io/packages/utils
-License text: 56
+License text: 57
 
 @typescript-eslint/visitor-keys 8.61.0
 License: MIT
 Homepage: https://typescript-eslint.io
-License text: 56
+License text: 57
 
 @uiw/codemirror-extensions-basic-setup 4.25.10
 License: MIT
@@ -1176,82 +1176,82 @@ License text: not present in the installed package
 @ungap/structured-clone 1.3.0
 License: ISC
 Homepage: https://github.com/ungap/structured-clone#readme
-License text: 59
+License text: 60
 
 @upsetjs/venn.js 2.0.0
 License: MIT
 Homepage: https://github.com/upsetjs/venn.js
-License text: 60
+License text: 61
 
 @vitejs/plugin-react 6.0.1
 License: MIT
 Homepage: https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#readme
-License text: 61
+License text: 62
 
 @vitest/expect 4.1.10
 License: MIT
 Homepage: https://vitest.dev/api/expect
-License text: 62
+License text: 63
 
 @vitest/mocker 4.1.10
 License: MIT
 Homepage: https://github.com/vitest-dev/vitest/tree/main/packages/mocker
-License text: 62
+License text: 63
 
 @vitest/pretty-format 4.1.10
 License: MIT
 Homepage: https://github.com/vitest-dev/vitest/tree/main/packages/pretty-format
-License text: 62
+License text: 63
 
 @vitest/runner 4.1.10
 License: MIT
 Homepage: https://vitest.dev/api/advanced/runner
-License text: 62
+License text: 63
 
 @vitest/snapshot 4.1.10
 License: MIT
 Homepage: https://vitest.dev/guide/snapshot
-License text: 62
+License text: 63
 
 @vitest/spy 4.1.10
 License: MIT
 Homepage: https://vitest.dev/api/mock
-License text: 62
+License text: 63
 
 @vitest/utils 4.1.10
 License: MIT
 Homepage: https://github.com/vitest-dev/vitest/tree/main/packages/utils
-License text: 62
+License text: 63
 
 @xmldom/xmldom 0.8.13, 0.9.10
 License: MIT
 Homepage: https://github.com/xmldom/xmldom
-License text: 63
+License text: 64
 
 abbrev 4.0.0
 License: ISC
 Homepage: https://github.com/npm/abbrev-js#readme
-License text: 64
+License text: 65
 
 acorn 8.16.0
 License: MIT
 Homepage: https://github.com/acornjs/acorn
-License text: 65
+License text: 66
 
 acorn-jsx 5.3.2
 License: MIT
 Homepage: https://github.com/acornjs/acorn-jsx
-License text: 66
+License text: 67
 
 agent-base 6.0.2, 7.1.4
 License: MIT
 Homepage: https://github.com/TooTallNate/proxy-agents#readme
-License text: 67
+License text: 68
 
 ajv 6.14.0, 8.20.0
 License: MIT
 Homepage: https://ajv.js.org
-License text: 68
+License text: 69, 70
 
 ansi-regex 5.0.1
 License: MIT
@@ -1266,12 +1266,12 @@ License text: 1
 any-promise 1.3.0
 License: MIT
 Homepage: http://github.com/kevinbeaty/any-promise
-License text: 69
+License text: 71
 
 anymatch 3.1.3
 License: ISC
 Homepage: https://github.com/micromatch/anymatch
-License text: 70
+License text: 72
 
 app-builder-lib 26.15.3
 License: MIT
@@ -1281,127 +1281,127 @@ License text: not present in the installed package
 arg 5.0.2
 License: MIT
 Homepage: https://github.com/vercel/arg#readme
-License text: 71
+License text: 73
 
 argparse 2.0.1
 License: Python-2.0
 Homepage: https://github.com/nodeca/argparse#readme
-License text: 72
+License text: 74
 
 aria-hidden 1.2.6
 License: MIT
 Homepage: https://github.com/theKashey/aria-hidden#readme
-License text: 73
+License text: 75
 
 aria-query 5.3.2
 License: Apache-2.0
 Homepage: https://github.com/A11yance/aria-query#readme
-License text: 74
+License text: 76
 
 array-buffer-byte-length 1.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/array-buffer-byte-length#readme
-License text: 75
+License text: 77
 
 array-includes 3.1.9
 License: MIT
 Homepage: https://github.com/es-shims/array-includes#readme
-License text: 76
+License text: 78
 
 array.prototype.flat 1.3.3
 License: MIT
 Homepage: https://github.com/es-shims/Array.prototype.flat#readme
-License text: 77
+License text: 79
 
 array.prototype.flatmap 1.3.3
 License: MIT
 Homepage: https://github.com/es-shims/Array.prototype.flatMap#readme
-License text: 77
+License text: 79
 
 arraybuffer.prototype.slice 1.0.4
 License: MIT
 Homepage: https://github.com/es-shims/ArrayBuffer.prototype.slice#readme
-License text: 78
+License text: 80
 
 asn1js 3.0.10
 License: BSD-3-Clause
 Homepage: https://github.com/PeculiarVentures/ASN1.js#readme
-License text: 79
+License text: 81
 
 assertion-error 2.0.1
 License: MIT
 Homepage: https://github.com/chaijs/assertion-error#readme
-License text: 80
+License text: 82
 
 ast-types-flow 0.0.8
 License: MIT
 Homepage: https://github.com/kyldvs/ast-types-flow#readme
-License text: 81
+License text: 83
 
 async 3.2.6
 License: MIT
 Homepage: https://caolan.github.io/async/
-License text: 82
+License text: 84
 
 async-exit-hook 2.0.1
 License: MIT
 Homepage: https://github.com/tapppi/async-exit-hook#readme
-License text: 83
+License text: 85
 
 async-function 1.0.0
 License: MIT
 Homepage: https://github.com/ljharb/async-function#readme
-License text: 84
+License text: 86
 
 asynckit 0.4.0
 License: MIT
 Homepage: https://github.com/alexindigo/asynckit#readme
-License text: 85
+License text: 87
 
 at-least-node 1.0.0
 License: ISC
 Homepage: https://github.com/RyanZim/at-least-node#readme
-License text: 86
+License text: 88
 
 autoprefixer 10.5.0
 License: MIT
 Homepage: https://github.com/postcss/autoprefixer#readme
-License text: 87
+License text: 89
 
 available-typed-arrays 1.0.7
 License: MIT
 Homepage: https://github.com/inspect-js/available-typed-arrays#readme
-License text: 88
+License text: 90
 
 aws4 1.13.2
 License: MIT
 Homepage: https://github.com/mhart/aws4#readme
-License text: 89
+License text: 91
 
 axe-core 4.12.1
 License: MPL-2.0
 Homepage: https://www.deque.com/axe/
-License text: 90, 91
+License text: 92, 93
 
 axios 1.18.1
 License: MIT
 Homepage: https://axios-http.com
-License text: 92
+License text: 94
 
 axobject-query 4.1.0
 License: Apache-2.0
 Homepage: https://github.com/A11yance/axobject-query#readme
-License text: 74
+License text: 76
 
 balanced-match 4.0.4
 License: MIT
 Homepage: https://github.com/juliangruber/balanced-match#readme
-License text: 93
+License text: 95
 
 base64-js 1.5.1
 License: MIT
 Homepage: https://github.com/beatgammit/base64-js
-License text: 94
+License text: 96
 
 baseline-browser-mapping 2.10.27
 License: Apache-2.0
@@ -1411,77 +1411,77 @@ License text: 10
 bidi-js 1.0.3
 License: MIT
 Homepage: https://github.com/lojjic/bidi-js#readme
-License text: 95
+License text: 97
 
 binary-extensions 2.3.0
 License: MIT
 Homepage: https://github.com/sindresorhus/binary-extensions#readme
-License text: 96
+License text: 98
 
 bluebird 3.7.2
 License: MIT
 Homepage: https://github.com/petkaantonov/bluebird
-License text: 97
+License text: 99
 
 brace-expansion 5.0.8
 License: MIT
 Homepage: https://github.com/juliangruber/brace-expansion#readme
-License text: 98
+License text: 100
 
 braces 3.0.3
 License: MIT
 Homepage: https://github.com/micromatch/braces
-License text: 99
+License text: 101
 
 browserslist 4.28.2
 License: MIT
 Homepage: https://github.com/browserslist/browserslist#readme
-License text: 100
+License text: 102
 
 buffer-from 1.1.2
 License: MIT
 Homepage: https://github.com/LinusU/buffer-from#readme
-License text: 101
+License text: 103
 
 builder-util 26.15.3
 License: MIT
 Homepage: https://github.com/electron-userland/electron-builder
-License text: 102
+License text: 104
 
 builder-util-runtime 9.7.0
 License: MIT
 Homepage: https://github.com/electron-userland/electron-builder
-License text: 102
+License text: 104
 
 bytestreamjs 2.0.1
 License: BSD-3-Clause
 Homepage: https://github.com/PeculiarVentures/ByteStream.js#readme
-License text: 103
+License text: 105
 
 cacheable-lookup 5.0.4
 License: MIT
 Homepage: https://github.com/szmarczak/cacheable-lookup#readme
-License text: 104
+License text: 106
 
 cacheable-request 7.0.4
 License: MIT
 Homepage: https://github.com/lukechilds/cacheable-request#readme
-License text: 105
+License text: 107
 
 call-bind 1.0.9
 License: MIT
 Homepage: https://github.com/ljharb/call-bind#readme
-License text: 106
+License text: 108
 
 call-bind-apply-helpers 1.0.2
 License: MIT
 Homepage: https://github.com/ljharb/call-bind-apply-helpers#readme
-License text: 107
+License text: 109
 
 call-bound 1.0.4
 License: MIT
 Homepage: https://github.com/ljharb/call-bound#readme
-License text: 107
+License text: 109
 
 callsites 3.1.0
 License: MIT
@@ -1491,17 +1491,17 @@ License text: 1
 camelcase-css 2.0.1
 License: MIT
 Homepage: https://github.com/stevenvachon/camelcase-css#readme
-License text: 108
+License text: 110
 
 caniuse-lite 1.0.30001791
 License: CC-BY-4.0
 Homepage: https://github.com/browserslist/caniuse-lite#readme
-License text: 109
+License text: 111
 
 chai 6.2.2
 License: MIT
 Homepage: http://chaijs.com
-License text: 110
+License text: 112
 
 chalk 4.1.2
 License: MIT
@@ -1511,12 +1511,12 @@ License text: 1
 chokidar 3.6.0, 4.0.3
 License: MIT
 Homepage: https://github.com/paulmillr/chokidar
-License text: 111
+License text: 113, 114
 
 chownr 3.0.0
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/chownr#readme
-License text: 112
+License text: 115
 
 chromium-pickle-js 0.2.0
 License: MIT
@@ -1526,32 +1526,32 @@ License text: not present in the installed package
 ci-info 4.3.1, 4.4.0
 License: MIT
 Homepage: https://github.com/watson/ci-info
-License text: 113
+License text: 116
 
 class-variance-authority 0.7.1
 License: Apache-2.0
 Homepage: https://github.com/joe-bell/cva#readme
-License text: 114
+License text: 117
 
 cliui 8.0.1
 License: ISC
 Homepage: https://github.com/yargs/cliui#readme
-License text: 115
+License text: 118
 
 clone-response 1.0.3
 License: MIT
 Homepage: https://github.com/sindresorhus/clone-response#readme
-License text: 105
+License text: 107
 
 clsx 2.1.1
 License: MIT
 Homepage: https://github.com/lukeed/clsx#readme
-License text: 116
+License text: 119
 
 cmdk 1.1.1
 License: MIT
 Homepage: https://github.com/pacocoursey/cmdk#readme
-License text: 117
+License text: 120
 
 codemirror 6.0.2
 License: MIT
@@ -1561,22 +1561,22 @@ License text: 11
 color-convert 2.0.1
 License: MIT
 Homepage: https://github.com/Qix-/color-convert#readme
-License text: 118
+License text: 121
 
 color-name 1.1.4
 License: MIT
 Homepage: https://github.com/colorjs/color-name
-License text: 119
+License text: 122
 
 combined-stream 1.0.8
 License: MIT
 Homepage: https://github.com/felixge/node-combined-stream
-License text: 120
+License text: 123
 
 commander 4.1.1, 5.1.0, 7.2.0, 8.3.0
 License: MIT
 Homepage: https://github.com/tj/commander.js#readme
-License text: 121
+License text: 124
 
 compare-version 0.1.2
 License: MIT
@@ -1586,332 +1586,332 @@ License text: not present in the installed package
 convert-source-map 2.0.0
 License: MIT
 Homepage: https://github.com/thlorenz/convert-source-map
-License text: 122
+License text: 125
 
 core-util-is 1.0.3
 License: MIT
 Homepage: https://github.com/isaacs/core-util-is#readme
-License text: 123
+License text: 126
 
 cose-base 1.0.3, 2.2.0
 License: MIT
 Homepage: https://github.com/iVis-at-Bilkent/cose-base#readme
-License text: 124
+License text: 127
 
 crelt 1.0.6
 License: MIT
 Homepage: https://github.com/marijnh/crelt#readme
-License text: 125
+License text: 128
 
 cross-spawn 7.0.6
 License: MIT
 Homepage: https://github.com/moxystudio/node-cross-spawn
-License text: 126
+License text: 129
 
 css-tree 3.2.1
 License: MIT
 Homepage: https://github.com/csstree/csstree#readme
-License text: 127
+License text: 130
 
 cssesc 3.0.0
 License: MIT
 Homepage: https://mths.be/cssesc
-License text: 128
+License text: 131
 
 csstype 3.2.3
 License: MIT
 Homepage: https://github.com/frenic/csstype#readme
-License text: 129
+License text: 132
 
 cytoscape 3.34.0
 License: MIT
 Homepage: http://js.cytoscape.org
-License text: 130, 131
+License text: 133, 134
 
 cytoscape-cose-bilkent 4.1.0
 License: MIT
 Homepage: https://github.com/cytoscape/cytoscape.js-cose-bilkent
-License text: 132
+License text: 135
 
 cytoscape-fcose 2.2.0
 License: MIT
 Homepage: https://github.com/iVis-at-Bilkent/cytoscape.js-fcose
-License text: 133
+License text: 136
 
 d3 7.9.0
 License: ISC
 Homepage: https://d3js.org
-License text: 134
+License text: 137
 
 d3-array 2.12.1
 License: BSD-3-Clause
 Homepage: https://d3js.org/d3-array/
-License text: 134
+License text: 138
 
 d3-array 3.2.4
 License: ISC
 Homepage: https://d3js.org/d3-array/
-License text: 134
+License text: 137
 
 d3-axis 3.0.0
 License: ISC
 Homepage: https://d3js.org/d3-axis/
-License text: 135
+License text: 139
 
 d3-brush 3.0.0
 License: ISC
 Homepage: https://d3js.org/d3-brush/
-License text: 135
+License text: 139
 
 d3-chord 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-chord/
-License text: 135
+License text: 139
 
 d3-color 3.1.0
 License: ISC
 Homepage: https://d3js.org/d3-color/
-License text: 136
+License text: 140
 
 d3-contour 4.0.2
 License: ISC
 Homepage: https://d3js.org/d3-contour/
-License text: 137
+License text: 141
 
 d3-delaunay 6.0.4
 License: ISC
 Homepage: https://github.com/d3/d3-delaunay
-License text: 138
+License text: 142
 
 d3-dispatch 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-dispatch/
-License text: 135
+License text: 139
 
 d3-drag 3.0.0
 License: ISC
 Homepage: https://d3js.org/d3-drag/
-License text: 135
+License text: 139
 
 d3-dsv 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-dsv/
-License text: 139
+License text: 143
 
 d3-ease 3.0.1
 License: BSD-3-Clause
 Homepage: https://d3js.org/d3-ease/
-License text: 140
+License text: 144
 
 d3-fetch 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-fetch/
-License text: 141
+License text: 145
 
 d3-force 3.0.0
 License: ISC
 Homepage: https://d3js.org/d3-force/
-License text: 135
+License text: 139
 
 d3-format 3.1.2
 License: ISC
 Homepage: https://d3js.org/d3-format/
-License text: 142
+License text: 146
 
 d3-geo 3.1.1
 License: ISC
 Homepage: https://d3js.org/d3-geo/
-License text: 143
+License text: 147
 
 d3-hierarchy 3.1.2
 License: ISC
 Homepage: https://d3js.org/d3-hierarchy/
-License text: 135
+License text: 139
 
 d3-interpolate 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-interpolate/
-License text: 135
+License text: 139
 
 d3-path 1.0.9
 License: BSD-3-Clause
 Homepage: https://d3js.org/d3-path/
-License text: 144
+License text: 148
 
 d3-path 3.1.0
 License: ISC
 Homepage: https://d3js.org/d3-path/
-License text: 144
+License text: 149
 
 d3-polygon 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-polygon/
-License text: 135
+License text: 139
 
 d3-quadtree 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-quadtree/
-License text: 135
+License text: 139
 
 d3-random 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-random/
-License text: 135
+License text: 139
 
 d3-sankey 0.12.3
 License: BSD-3-Clause
 Homepage: https://github.com/d3/d3-sankey
-License text: 145
+License text: 150
 
 d3-scale 4.0.2
 License: ISC
 Homepage: https://d3js.org/d3-scale/
-License text: 135
+License text: 139
 
 d3-scale-chromatic 3.1.0
 License: ISC
 Homepage: https://d3js.org/d3-scale-chromatic/
-License text: 146
+License text: 151
 
 d3-selection 3.0.0
 License: ISC
 Homepage: https://d3js.org/d3-selection/
-License text: 135
+License text: 139
 
 d3-shape 1.3.7
 License: BSD-3-Clause
 Homepage: https://d3js.org/d3-shape/
-License text: 136
+License text: 152
 
 d3-shape 3.2.0
 License: ISC
 Homepage: https://d3js.org/d3-shape/
-License text: 136
+License text: 140
 
 d3-time 3.1.0
 License: ISC
 Homepage: https://d3js.org/d3-time/
-License text: 136
+License text: 140
 
 d3-time-format 4.1.0
 License: ISC
 Homepage: https://d3js.org/d3-time-format/
-License text: 135
+License text: 139
 
 d3-timer 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-timer/
-License text: 135
+License text: 139
 
 d3-transition 3.0.1
 License: ISC
 Homepage: https://d3js.org/d3-transition/
-License text: 135
+License text: 139
 
 d3-zoom 3.0.0
 License: ISC
 Homepage: https://d3js.org/d3-zoom/
-License text: 135
+License text: 139
 
 dagre-d3-es 7.0.14
 License: MIT
 Homepage: https://github.com/tbo47/dagre-es#readme
-License text: 147
+License text: 153
 
 damerau-levenshtein 1.0.8
 License: BSD-2-Clause
 Homepage: https://github.com/tad-lispy/node-damerau-levenshtein#readme
-License text: 148
+License text: 154
 
 data-urls 7.0.0
 License: MIT
 Homepage: https://github.com/jsdom/data-urls#readme
-License text: 149
+License text: 155
 
 data-view-buffer 1.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/data-view-buffer#readme
-License text: 150
+License text: 156
 
 data-view-byte-length 1.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/data-view-byte-length#readme
-License text: 107
+License text: 109
 
 data-view-byte-offset 1.0.1
 License: MIT
 Homepage: https://github.com/inspect-js/data-view-byte-offset#readme
-License text: 107
+License text: 109
 
 dayjs 1.11.20
 License: MIT
 Homepage: https://day.js.org
-License text: 151
+License text: 157
 
 debug 4.4.3
 License: MIT
 Homepage: https://github.com/debug-js/debug#readme
-License text: 152
+License text: 158
 
 decimal.js 10.6.0
 License: MIT
 Homepage: https://github.com/MikeMcl/decimal.js#readme
-License text: 153
+License text: 159
 
 decompress-response 6.0.0
 License: MIT
 Homepage: https://github.com/sindresorhus/decompress-response#readme
-License text: 52
+License text: 53
 
 deep-is 0.1.4
 License: MIT
 Homepage: https://github.com/thlorenz/deep-is#readme
-License text: 154
+License text: 160
 
 defer-to-connect 2.0.1
 License: MIT
 Homepage: https://github.com/szmarczak/defer-to-connect#readme
-License text: 54
+License text: 55
 
 define-data-property 1.1.4
 License: MIT
 Homepage: https://github.com/ljharb/define-data-property#readme
-License text: 150
+License text: 156
 
 define-properties 1.2.1
 License: MIT
 Homepage: https://github.com/ljharb/define-properties#readme
-License text: 76
+License text: 78
 
 delaunator 5.1.0
 License: ISC
 Homepage: https://github.com/mapbox/delaunator#readme
-License text: 155
+License text: 161
 
 delayed-stream 1.0.0
 License: MIT
 Homepage: https://github.com/felixge/node-delayed-stream
-License text: 120
+License text: 123
 
 detect-libc 2.1.2
 License: Apache-2.0
 Homepage: https://github.com/lovell/detect-libc#readme
-License text: 156
+License text: 162
 
 detect-node-es 1.1.0
 License: MIT
 Homepage: https://github.com/thekashey/detect-node
-License text: 157
+License text: 163
 
 didyoumean 1.2.2
 License: Apache-2.0
 Homepage: https://github.com/dcporter/didyoumean.js
-License text: 158
+License text: 164
 
 dir-compare 4.2.0
 License: MIT
 Homepage: https://github.com/gliviu/dir-compare#readme
-License text: 159
+License text: 165
 
 dlv 1.1.3
 License: MIT
@@ -1926,42 +1926,42 @@ License text: not present in the installed package
 dnd-core 16.0.1
 License: MIT
 Homepage: https://github.com/react-dnd/react-dnd#readme
-License text: 160
+License text: 166
 
 doctrine 3.0.0
 License: Apache-2.0
 Homepage: https://github.com/eslint/doctrine
-License text: 161, 10, 162
+License text: 10, 167, 168
 
 docx 9.7.1
 License: MIT
 Homepage: https://docx.js.org
-License text: 163
+License text: 169
 
 dompurify 3.4.12
 License: (MPL-2.0 OR Apache-2.0)
 Homepage: https://github.com/cure53/DOMPurify
-License text: 10, 164
+License text: 10, 170
 
 dotenv 16.6.1
 License: BSD-2-Clause
 Homepage: https://github.com/motdotla/dotenv#readme
-License text: 165
+License text: 171
 
 dotenv-expand 11.0.7
 License: BSD-2-Clause
 Homepage: https://github.com/motdotla/dotenv-expand#readme
-License text: 166
+License text: 172
 
 dunder-proto 1.0.1
 License: MIT
 Homepage: https://github.com/es-shims/dunder-proto#readme
-License text: 167
+License text: 173
 
 duplexer2 0.1.4
 License: BSD-3-Clause
 Homepage: https://github.com/deoxxa/duplexer2#readme
-License text: 168
+License text: 174
 
 ejs 3.1.10
 License: Apache-2.0
@@ -1971,62 +1971,62 @@ License text: 10
 electron 43.1.1
 License: MIT
 Homepage: https://github.com/electron/electron#readme
-License text: 169
+License text: 175
 
 electron-builder 26.15.3
 License: MIT
 Homepage: https://github.com/electron-userland/electron-builder
-License text: 102
+License text: 104
 
 electron-builder-squirrel-windows 26.15.3
 License: MIT
 Homepage: https://github.com/electron-userland/electron-builder
-License text: 102
+License text: 104
 
 electron-log 5.4.4
 License: MIT
 Homepage: https://github.com/megahertz/electron-log#readme
-License text: 170
+License text: 176
 
 electron-publish 26.15.3
 License: MIT
 Homepage: https://github.com/electron-userland/electron-builder
-License text: 102
+License text: 104
 
 electron-to-chromium 1.5.350
 License: ISC
 Homepage: https://github.com/Kilian/electron-to-chromium#readme
-License text: 171
+License text: 177
 
 electron-updater 6.8.9
 License: MIT
 Homepage: https://github.com/electron-userland/electron-builder
-License text: 102
+License text: 104
 
 electron-winstaller 5.4.0
 License: MIT
 Homepage: https://github.com/electron/windows-installer#readme
-License text: 172
+License text: 178
 
 emoji-regex 8.0.0, 9.2.2
 License: MIT
 Homepage: https://mths.be/emoji-regex
-License text: 128
+License text: 131
 
 end-of-stream 1.4.5
 License: MIT
 Homepage: https://github.com/mafintosh/end-of-stream
-License text: 173
+License text: 179
 
 entities 8.0.0
 License: BSD-2-Clause
 Homepage: https://github.com/fb55/entities#readme
-License text: 174
+License text: 180
 
 env-paths 2.2.1, 3.0.0
 License: MIT
 Homepage: https://github.com/sindresorhus/env-paths#readme
-License text: 1
+License text: 53, 1
 
 err-code 2.0.3
 License: MIT
@@ -2036,57 +2036,57 @@ License text: not present in the installed package
 es-abstract 1.24.2
 License: MIT
 Homepage: https://github.com/ljharb/es-abstract#readme
-License text: 76
+License text: 78
 
 es-define-property 1.0.1
 License: MIT
 Homepage: https://github.com/ljharb/es-define-property#readme
-License text: 107
+License text: 109
 
 es-errors 1.3.0
 License: MIT
 Homepage: https://github.com/ljharb/es-errors#readme
-License text: 107
+License text: 109
 
 es-module-lexer 2.3.1
 License: MIT
 Homepage: https://github.com/guybedford/es-module-lexer#readme
-License text: 175
+License text: 181
 
 es-object-atoms 1.1.1, 1.1.2
 License: MIT
 Homepage: https://github.com/ljharb/es-object-atoms#readme
-License text: 107
+License text: 109
 
 es-set-tostringtag 2.1.0
 License: MIT
 Homepage: https://github.com/es-shims/es-set-tostringtag#readme
-License text: 176
+License text: 182
 
 es-shim-unscopables 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/es-shim-unscopables#readme
-License text: 177
+License text: 183
 
 es-to-primitive 1.3.0
 License: MIT
 Homepage: https://github.com/ljharb/es-to-primitive#readme
-License text: 178
+License text: 184
 
 es-toolkit 1.47.0
 License: MIT
 Homepage: https://es-toolkit.dev
-License text: 179
+License text: 185
 
 escalade 3.2.0
 License: MIT
 Homepage: https://github.com/lukeed/escalade#readme
-License text: 116
+License text: 119
 
 escape-string-regexp 4.0.0
 License: MIT
 Homepage: https://github.com/sindresorhus/escape-string-regexp#readme
-License text: 52
+License text: 53
 
 eslint 8.57.1
 License: MIT
@@ -2096,37 +2096,37 @@ License text: 23
 eslint-plugin-jsx-a11y 6.10.2
 License: MIT
 Homepage: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#readme
-License text: 180
+License text: 186
 
 eslint-plugin-react-hooks 4.6.2
 License: MIT
 Homepage: https://reactjs.org/
-License text: 181
+License text: 187
 
 eslint-plugin-sonarjs 1.0.4
 License: LGPL-3.0-only
 Homepage: https://github.com/SonarSource/eslint-plugin-sonarjs
-License text: 182
+License text: 188
 
 eslint-scope 7.2.2
 License: BSD-2-Clause
 Homepage: http://github.com/eslint/eslint-scope
-License text: 183
+License text: 189
 
 eslint-visitor-keys 3.4.3, 5.0.1
 License: Apache-2.0
 Homepage: https://github.com/eslint/js/blob/main/packages/eslint-visitor-keys/README.md
-License text: 184
+License text: 190
 
 espree 9.6.1
 License: BSD-2-Clause
 Homepage: https://github.com/eslint/espree
-License text: 185
+License text: 191
 
 esquery 1.7.0
 License: BSD-3-Clause
 Homepage: https://github.com/estools/esquery/
-License text: 186
+License text: 192
 
 esrecurse 4.3.0
 License: BSD-2-Clause
@@ -2136,37 +2136,37 @@ License text: not present in the installed package
 estraverse 5.3.0
 License: BSD-2-Clause
 Homepage: https://github.com/estools/estraverse
-License text: 162
+License text: 168
 
 estree-walker 3.0.3
 License: MIT
 Homepage: https://github.com/Rich-Harris/estree-walker#readme
-License text: 187
+License text: 193
 
 esutils 2.0.3
 License: BSD-2-Clause
 Homepage: https://github.com/estools/esutils
-License text: 162
+License text: 168
 
 expect-type 1.4.0
 License: Apache-2.0
 Homepage: https://github.com/mmkal/expect-type#readme
-License text: 188
+License text: 194
 
 exponential-backoff 3.1.3
 License: Apache-2.0
 Homepage: https://github.com/coveooss/exponential-backoff#readme
-License text: 189
+License text: 195
 
 fake-indexeddb 6.2.5
 License: Apache-2.0
 Homepage: https://github.com/dumbmatter/fakeIndexedDB
-License text: 190
+License text: 196
 
 fast-deep-equal 3.1.3
 License: MIT
 Homepage: https://github.com/epoberezkin/fast-deep-equal#readme
-License text: 191
+License text: 197
 
 fast-glob 3.3.3
 License: MIT
@@ -2176,32 +2176,32 @@ License text: 40
 fast-json-stable-stringify 2.1.0
 License: MIT
 Homepage: https://github.com/epoberezkin/fast-json-stable-stringify
-License text: 192
+License text: 198
 
 fast-levenshtein 2.0.6
 License: MIT
 Homepage: https://github.com/hiddentao/fast-levenshtein#readme
-License text: 193
+License text: 199
 
 fast-uri 3.1.4
 License: BSD-3-Clause
 Homepage: https://github.com/fastify/fast-uri
-License text: 194
+License text: 200
 
 fastq 1.20.1
 License: ISC
 Homepage: https://github.com/mcollina/fastq#readme
-License text: 195
+License text: 201
 
 fdir 6.5.0
 License: MIT
 Homepage: https://github.com/thecodrr/fdir#readme
-License text: 196
+License text: 202
 
 file-entry-cache 6.0.1
 License: MIT
 Homepage: https://github.com/royriojas/file-entry-cache#readme
-License text: 197
+License text: 203
 
 filelist 1.0.6
 License: Apache-2.0
@@ -2211,127 +2211,127 @@ License text: not present in the installed package
 fill-range 7.1.1
 License: MIT
 Homepage: https://github.com/jonschlinkert/fill-range
-License text: 99
+License text: 101
 
 find-up 5.0.0
 License: MIT
 Homepage: https://github.com/sindresorhus/find-up#readme
-License text: 52
+License text: 53
 
 flat-cache 3.2.0
 License: MIT
 Homepage: https://github.com/jaredwray/flat-cache#readme
-License text: 198
+License text: 204
 
 flatted 3.4.2
 License: ISC
 Homepage: https://github.com/WebReflection/flatted#readme
-License text: 199
+License text: 205
 
 follow-redirects 1.16.0
 License: MIT
 Homepage: https://github.com/follow-redirects/follow-redirects
-License text: 200
+License text: 206
 
 for-each 0.3.5
 License: MIT
 Homepage: https://github.com/Raynos/for-each
-License text: 201
+License text: 207
 
 form-data 4.0.6
 License: MIT
 Homepage: https://github.com/form-data/form-data#readme
-License text: 202
+License text: 208
 
 fraction.js 5.3.4
 License: MIT
 Homepage: https://raw.org/article/rational-numbers-in-javascript/
-License text: 203
+License text: 209
 
 fs-extra 7.0.1, 8.1.0, 9.1.0, 10.1.0, 11.3.1, 11.3.6
 License: MIT
 Homepage: https://github.com/jprichardson/node-fs-extra
-License text: 204
+License text: 210, 211
 
 fs.realpath 1.0.0
 License: ISC
 Homepage: https://github.com/isaacs/fs.realpath#readme
-License text: 205
+License text: 212
 
 function-bind 1.1.2
 License: MIT
 Homepage: https://github.com/Raynos/function-bind
-License text: 206
+License text: 213
 
 function.prototype.name 1.2.0
 License: MIT
 Homepage: https://github.com/es-shims/Function.prototype.name#readme
-License text: 207
+License text: 214
 
 functions-have-names 1.2.3
 License: MIT
 Homepage: https://github.com/inspect-js/functions-have-names#readme
-License text: 208
+License text: 215
 
 generator-function 2.0.1
 License: MIT
 Homepage: https://github.com/TimothyGu/generator-function#readme
-License text: 209
+License text: 216
 
 get-caller-file 2.0.5
 License: ISC
 Homepage: https://github.com/stefanpenner/get-caller-file#readme
-License text: 210
+License text: 217
 
 get-intrinsic 1.3.0
 License: MIT
 Homepage: https://github.com/ljharb/get-intrinsic#readme
-License text: 106
+License text: 108
 
 get-nonce 1.0.1
 License: MIT
 Homepage: https://github.com/theKashey/get-nonce
-License text: 211
+License text: 218
 
 get-proto 1.0.1
 License: MIT
 Homepage: https://github.com/ljharb/get-proto#readme
-License text: 212
+License text: 219
 
 get-stream 5.2.0
 License: MIT
 Homepage: https://github.com/sindresorhus/get-stream#readme
-License text: 52
+License text: 53
 
 get-symbol-description 1.1.0
 License: MIT
 Homepage: https://github.com/inspect-js/get-symbol-description#readme
-License text: 213
+License text: 220
 
 glob 7.2.3
 License: ISC
 Homepage: https://github.com/isaacs/node-glob#readme
-License text: 214
+License text: 221
 
 glob-parent 5.1.2, 6.0.2
 License: ISC
 Homepage: https://github.com/gulpjs/glob-parent#readme
-License text: 215
+License text: 222, 223
 
 globals 13.24.0
 License: MIT
 Homepage: https://github.com/sindresorhus/globals#readme
-License text: 52
+License text: 53
 
 globalthis 1.0.4
 License: MIT
 Homepage: https://github.com/ljharb/System.global#readme
-License text: 207
+License text: 214
 
 gopd 1.2.0
 License: MIT
 Homepage: https://github.com/ljharb/gopd#readme
-License text: 177
+License text: 183
 
 got 11.8.6
 License: MIT
@@ -2341,27 +2341,27 @@ License text: 1
 graceful-fs 4.2.11
 License: ISC
 Homepage: https://github.com/isaacs/node-graceful-fs#readme
-License text: 216
+License text: 224
 
 graphemer 1.4.0
 License: MIT
 Homepage: https://github.com/flmnt/graphemer
-License text: 217
+License text: 225
 
 hachure-fill 0.5.2
 License: MIT
 Homepage: https://github.com/pshihn/hachure-fill#readme
-License text: 218
+License text: 226
 
 hammerjs 2.0.8
 License: MIT
 Homepage: http://hammerjs.github.io/
-License text: 219
+License text: 227
 
 has-bigints 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/has-bigints#readme
-License text: 208
+License text: 215
 
 has-flag 4.0.0
 License: MIT
@@ -2371,22 +2371,22 @@ License text: 1
 has-property-descriptors 1.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/has-property-descriptors#readme
-License text: 220
+License text: 228
 
 has-proto 1.2.0
 License: MIT
 Homepage: https://github.com/inspect-js/has-proto#readme
-License text: 220
+License text: 228
 
 has-symbols 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/has-symbols#readme
-License text: 221
+License text: 229
 
 has-tostringtag 1.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/has-tostringtag#readme
-License text: 213
+License text: 220
 
 hash.js 1.1.7
 License: MIT
@@ -2396,22 +2396,22 @@ License text: not present in the installed package
 hasown 2.0.3, 2.0.4
 License: MIT
 Homepage: https://github.com/inspect-js/hasOwn#readme
-License text: 222
+License text: 230
 
 hoist-non-react-statics 3.3.2
 License: BSD-3-Clause
 Homepage: https://github.com/mridgway/hoist-non-react-statics#readme
-License text: 223
+License text: 231
 
 hosted-git-info 4.1.0
 License: ISC
 Homepage: https://github.com/npm/hosted-git-info
-License text: 224
+License text: 232
 
 html-encoding-sniffer 6.0.0
 License: MIT
 Homepage: https://github.com/jsdom/html-encoding-sniffer#readme
-License text: 149
+License text: 155
 
 html-parse-stringify 3.0.1
 License: MIT
@@ -2421,62 +2421,62 @@ License text: not present in the installed package
 http-cache-semantics 4.2.0
 License: BSD-2-Clause
 Homepage: https://github.com/kornelski/http-cache-semantics#readme
-License text: 225
+License text: 233
 
 http-proxy-agent 7.0.2
 License: MIT
 Homepage: https://github.com/TooTallNate/proxy-agents#readme
-License text: 67
+License text: 68
 
 http2-wrapper 1.0.3
 License: MIT
 Homepage: https://github.com/szmarczak/http2-wrapper#readme
-License text: 54
+License text: 55
 
 https-proxy-agent 5.0.1, 7.0.6
 License: MIT
 Homepage: https://github.com/TooTallNate/proxy-agents#readme
-License text: not present in the installed package
+License text: 68
 
 i18next 26.3.1
 License: MIT
 Homepage: https://www.i18next.com
-License text: 226
+License text: 234
 
 iconv-lite 0.6.3
 License: MIT
 Homepage: https://github.com/ashtuchkin/iconv-lite
-License text: 227
+License text: 235
 
 idb 8.0.3
 License: ISC
 Homepage: https://github.com/jakearchibald/idb#readme
-License text: 228
+License text: 236
 
 ignore 5.3.2, 7.0.5
 License: MIT
 Homepage: https://github.com/kaelzhang/node-ignore#readme
-License text: 229
+License text: 237
 
 immediate 3.0.6
 License: MIT
 Homepage: https://github.com/calvinmetcalf/immediate#readme
-License text: 230
+License text: 238
 
 immutable 5.1.8
 License: MIT
 Homepage: https://immutable-js.com
-License text: 231
+License text: 239
 
 import-fresh 3.3.1
 License: MIT
 Homepage: https://github.com/sindresorhus/import-fresh#readme
-License text: 52
+License text: 53
 
 import-meta-resolve 4.2.0
 License: MIT
 Homepage: https://github.com/wooorm/import-meta-resolve#readme
-License text: 232
+License text: 240
 
 imurmurhash 0.1.4
 License: MIT
@@ -2486,82 +2486,82 @@ License text: not present in the installed package
 inflight 1.0.6
 License: ISC
 Homepage: https://github.com/isaacs/inflight
-License text: 233
+License text: 241
 
 inherits 2.0.4
 License: ISC
 Homepage: https://github.com/isaacs/inherits#readme
-License text: 234
+License text: 242
 
 internal-slot 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/internal-slot#readme
-License text: 208
+License text: 215
 
 internmap 1.0.1, 2.0.3
 License: ISC
 Homepage: https://github.com/mbostock/internmap/
-License text: 235
+License text: 243
 
 is-array-buffer 3.0.5
 License: MIT
 Homepage: https://github.com/inspect-js/is-array-buffer#readme
-License text: 236
+License text: 244
 
 is-async-function 2.1.1
 License: MIT
 Homepage: https://github.com/inspect-js/is-async-function#readme
-License text: 237
+License text: 245
 
 is-bigint 1.1.0
 License: MIT
 Homepage: https://github.com/inspect-js/is-bigint#readme
-License text: 238
+License text: 246
 
 is-binary-path 2.1.0
 License: MIT
 Homepage: https://github.com/sindresorhus/is-binary-path#readme
-License text: 239
+License text: 247
 
 is-boolean-object 1.2.2
 License: MIT
 Homepage: https://github.com/inspect-js/is-boolean-object#readme
-License text: 178
+License text: 184
 
 is-callable 1.2.7
 License: MIT
 Homepage: https://github.com/inspect-js/is-callable#readme
-License text: 178
+License text: 184
 
 is-core-module 2.16.2
 License: MIT
 Homepage: https://github.com/inspect-js/is-core-module
-License text: 240
+License text: 248
 
 is-data-view 1.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/is-data-view#readme
-License text: 241
+License text: 249
 
 is-date-object 1.1.0
 License: MIT
 Homepage: https://github.com/inspect-js/is-date-object#readme
-License text: 178
+License text: 184
 
 is-document.all 1.0.0
 License: MIT
 Homepage: https://github.com/inspect-js/is-document.all#readme
-License text: 242
+License text: 250
 
 is-extglob 2.1.1
 License: MIT
 Homepage: https://github.com/jonschlinkert/is-extglob
-License text: 243
+License text: 251
 
 is-finalizationregistry 1.1.1
 License: MIT
 Homepage: https://github.com/inspect-js/is-finalizationregistry#readme
-License text: 88
+License text: 90
 
 is-fullwidth-code-point 3.0.0
 License: MIT
@@ -2571,32 +2571,32 @@ License text: 1
 is-generator-function 1.1.2
 License: MIT
 Homepage: https://github.com/inspect-js/is-generator-function#readme
-License text: 244
+License text: 252
 
 is-glob 4.0.3
 License: MIT
 Homepage: https://github.com/micromatch/is-glob
-License text: 245
+License text: 253
 
 is-map 2.0.3
 License: MIT
 Homepage: https://github.com/inspect-js/is-map#readme
-License text: 246
+License text: 254
 
 is-negative-zero 2.0.3
 License: MIT
 Homepage: https://github.com/inspect-js/is-negative-zero
-License text: 244
+License text: 252
 
 is-number 7.0.0
 License: MIT
 Homepage: https://github.com/jonschlinkert/is-number
-License text: 99
+License text: 101
 
 is-number-object 1.1.1
 License: MIT
 Homepage: https://github.com/inspect-js/is-number-object#readme
-License text: 178
+License text: 184
 
 is-path-inside 3.0.3
 License: MIT
@@ -2606,62 +2606,62 @@ License text: 1
 is-potential-custom-element-name 1.0.1
 License: MIT
 Homepage: https://github.com/mathiasbynens/is-potential-custom-element-name
-License text: 128
+License text: 131
 
 is-regex 1.2.1
 License: MIT
 Homepage: https://github.com/inspect-js/is-regex
-License text: 244
+License text: 252
 
 is-set 2.0.3
 License: MIT
 Homepage: https://github.com/inspect-js/is-set#readme
-License text: 246
+License text: 254
 
 is-shared-array-buffer 1.0.4
 License: MIT
 Homepage: https://github.com/inspect-js/is-shared-array-buffer#readme
-License text: 213
+License text: 220
 
 is-string 1.1.1
 License: MIT
 Homepage: https://github.com/inspect-js/is-string#readme
-License text: 178
+License text: 184
 
 is-symbol 1.1.1
 License: MIT
 Homepage: https://github.com/inspect-js/is-symbol#readme
-License text: 178
+License text: 184
 
 is-typed-array 1.1.15
 License: MIT
 Homepage: https://github.com/inspect-js/is-typed-array#readme
-License text: 178
+License text: 184
 
 is-weakmap 2.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/is-weakmap#readme
-License text: 246
+License text: 254
 
 is-weakref 1.1.1
 License: MIT
 Homepage: https://github.com/inspect-js/is-weakref#readme
-License text: 88
+License text: 90
 
 is-weakset 2.0.4
 License: MIT
 Homepage: https://github.com/inspect-js/is-weakset#readme
-License text: 246
+License text: 254
 
 isarray 1.0.0, 2.0.5
 License: MIT
 Homepage: https://github.com/juliangruber/isarray
-License text: 247
+License text: 255
 
 isbinaryfile 4.0.10, 5.0.7
 License: MIT
 Homepage: https://github.com/gjtorikian/isBinaryFile#readme
-License text: 248
+License text: 256
 
 isexe 2.0.0
 License: ISC
@@ -2671,7 +2671,7 @@ License text: 29
 isexe 3.1.5, 4.0.0
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/isexe#readme
-License text: 29
+License text: 257
 
 jake 10.9.4
 License: Apache-2.0
@@ -2681,12 +2681,12 @@ License text: not present in the installed package
 jiti 1.21.7, 2.7.0
 License: MIT
 Homepage: https://github.com/unjs/jiti#readme
-License text: 249
+License text: 258
 
 jotai 2.15.2
 License: MIT
 Homepage: https://github.com/pmndrs/jotai
-License text: 250
+License text: 259
 
 jotai-x 2.3.3
 License: MIT
@@ -2696,57 +2696,57 @@ License text: not present in the installed package
 js-tokens 4.0.0
 License: MIT
 Homepage: https://github.com/lydell/js-tokens#readme
-License text: 251
+License text: 260
 
 js-yaml 4.3.0
 License: MIT
 Homepage: https://github.com/nodeca/js-yaml#readme
-License text: 252
+License text: 261
 
 jsdom 29.1.1
 License: MIT
 Homepage: https://github.com/jsdom/jsdom#readme
-License text: 253
+License text: 262
 
 json-buffer 3.0.1
 License: MIT
 Homepage: https://github.com/dominictarr/json-buffer
-License text: 254
+License text: 263
 
 json-schema-traverse 0.4.1, 1.0.0
 License: MIT
 Homepage: https://github.com/epoberezkin/json-schema-traverse#readme
-License text: 191
+License text: 197
 
 json-stable-stringify-without-jsonify 1.0.1
 License: MIT
 Homepage: https://github.com/samn/json-stable-stringify
-License text: 255
+License text: 264
 
 json5 2.2.3
 License: MIT
 Homepage: http://json5.org/
-License text: 256
+License text: 265
 
 jsonfile 4.0.0, 6.2.1
 License: MIT
 Homepage: https://github.com/jprichardson/node-jsonfile#readme
-License text: 257
+License text: 266
 
 jsx-ast-utils 3.3.5
 License: MIT
 Homepage: https://github.com/jsx-eslint/jsx-ast-utils#readme
-License text: 180
+License text: 186
 
 jszip 3.10.1
 License: (MIT OR GPL-3.0-or-later)
 Homepage: https://github.com/Stuk/jszip#readme
-License text: 258
+License text: 267
 
 katex 0.16.45, 0.17.0
 License: MIT
 Homepage: https://katex.org
-License text: 259
+License text: 268
 
 keyv 4.5.4
 License: MIT
@@ -2756,7 +2756,7 @@ License text: not present in the installed package
 khroma 2.1.0
 License: Unknown
 Homepage: https://github.com/fabiospampinato/khroma#readme
-License text: 260
+License text: 269
 
 language-subtag-registry 0.3.23
 License: CC0-1.0
@@ -2771,7 +2771,7 @@ License text: not present in the installed package
 layout-base 1.0.2, 2.0.1
 License: MIT
 Homepage: https://github.com/iVis-at-Bilkent/layout-base#readme
-License text: 261
+License text: 270
 
 lazy-val 1.0.5
 License: MIT
@@ -2781,62 +2781,62 @@ License text: not present in the installed package
 levn 0.4.1
 License: MIT
 Homepage: https://github.com/gkz/levn
-License text: 262
+License text: 271
 
 lie 3.3.0
 License: MIT
 Homepage: https://github.com/calvinmetcalf/lie#readme
-License text: 263
+License text: 272
 
 lightningcss 1.32.0
 License: MPL-2.0
 Homepage: https://github.com/parcel-bundler/lightningcss#readme
-License text: 264
+License text: 273
 
 lilconfig 3.1.3
 License: MIT
 Homepage: https://github.com/antonk52/lilconfig#readme
-License text: 265
+License text: 274
 
 lines-and-columns 1.2.4
 License: MIT
 Homepage: https://github.com/eventualbuddha/lines-and-columns#readme
-License text: 266
+License text: 275
 
 locate-path 6.0.0
 License: MIT
 Homepage: https://github.com/sindresorhus/locate-path#readme
-License text: 52
+License text: 53
 
 lodash 4.18.1
 License: MIT
 Homepage: https://lodash.com/
-License text: 267
+License text: 276
 
 lodash-es 4.18.1
 License: MIT
 Homepage: https://lodash.com/custom-builds
-License text: 267
+License text: 276
 
 lodash.escaperegexp 4.1.2
 License: MIT
 Homepage: https://lodash.com/
-License text: 268
+License text: 277
 
 lodash.isequal 4.5.0
 License: MIT
 Homepage: https://lodash.com/
-License text: 269
+License text: 278
 
 lodash.merge 4.6.2
 License: MIT
 Homepage: https://lodash.com/
-License text: 267
+License text: 276
 
 loose-envify 1.4.0
 License: MIT
 Homepage: https://github.com/zertosh/loose-envify
-License text: 270
+License text: 279
 
 lowercase-keys 2.0.0
 License: MIT
@@ -2846,122 +2846,122 @@ License text: 1
 lru-cache 11.5.2
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/node-lru-cache#readme
-License text: 271
+License text: 257
 
 lru-cache 6.0.0, 10.2.0
 License: ISC
 Homepage: https://github.com/isaacs/node-lru-cache#readme
-License text: 271
+License text: 280, 29
 
 lucide-react 1.14.0
 License: ISC
 Homepage: https://lucide.dev
-License text: 272
+License text: 281
 
 magic-string 0.30.21
 License: MIT
 Homepage: https://github.com/Rich-Harris/magic-string#readme
-License text: 273
+License text: 282
 
 marked 12.0.2, 16.4.2
 License: MIT
 Homepage: https://marked.js.org
-License text: 274
+License text: 283
 
 math-intrinsics 1.1.0
 License: MIT
 Homepage: https://github.com/es-shims/math-intrinsics#readme
-License text: 167
+License text: 173
 
 mdn-data 2.27.1
 License: CC0-1.0
 Homepage: https://developer.mozilla.org
-License text: 275
+License text: 284
 
 merge2 1.4.1
 License: MIT
 Homepage: https://github.com/teambition/merge2
-License text: 276
+License text: 285
 
 mermaid 11.15.0
 License: MIT
 Homepage: https://github.com/mermaid-js/mermaid#readme
-License text: 277
+License text: 286
 
 micromatch 4.0.8
 License: MIT
 Homepage: https://github.com/micromatch/micromatch
-License text: 99
+License text: 101
 
 mime 2.6.0
 License: MIT
 Homepage: https://github.com/broofa/mime#readme
-License text: 278
+License text: 287
 
 mime-db 1.52.0
 License: MIT
 Homepage: https://github.com/jshttp/mime-db#readme
-License text: 279
+License text: 288
 
 mime-types 2.1.35
 License: MIT
 Homepage: https://github.com/jshttp/mime-types#readme
-License text: 280
+License text: 289
 
 mimic-response 1.0.1, 3.1.0
 License: MIT
 Homepage: https://github.com/sindresorhus/mimic-response#readme
-License text: 1
+License text: 53, 1
 
 minimalistic-assert 1.0.1
 License: ISC
 Homepage: https://github.com/calvinmetcalf/minimalistic-assert
-License text: 281
+License text: 290
 
 minimatch 10.2.5
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/minimatch#readme
-License text: 29
+License text: 291
 
 minimatch 3.1.5, 5.1.9, 9.0.9
 License: ISC
 Homepage: https://github.com/isaacs/minimatch#readme
-License text: 29
+License text: 292, 29
 
 minimist 1.2.8
 License: MIT
 Homepage: https://github.com/minimistjs/minimist
-License text: 255
+License text: 264
 
 minipass 7.1.3
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/minipass#readme
-License text: 282
+License text: 257
 
 minizlib 3.1.0
 License: MIT
 Homepage: https://github.com/isaacs/minizlib#readme
-License text: 283
+License text: 293
 
 mkdirp 0.5.6
 License: MIT
 Homepage: https://github.com/substack/node-mkdirp#readme
-License text: 284
+License text: 294
 
 ms 2.1.3
 License: MIT
 Homepage: https://github.com/vercel/ms#readme
-License text: 285
+License text: 295
 
 mz 2.7.0
 License: MIT
 Homepage: https://github.com/normalize/mz#readme
-License text: 286
+License text: 296
 
 nanoid 3.3.16, 5.1.11
 License: MIT
 Homepage: https://github.com/ai/nanoid#readme
-License text: 287
+License text: 297, 298
 
 natural-compare 1.4.0
 License: MIT
@@ -2971,7 +2971,7 @@ License text: not present in the installed package
 node-abi 4.33.0
 License: MIT
 Homepage: https://github.com/electron/node-abi#readme
-License text: 288
+License text: 299
 
 node-api-version 0.2.1
 License: MIT
@@ -2981,17 +2981,17 @@ License text: not present in the installed package
 node-gyp 12.4.0
 License: MIT
 Homepage: https://github.com/nodejs/node-gyp#readme
-License text: 289
+License text: 300
 
 node-int64 0.4.0
 License: MIT
 Homepage: https://github.com/broofa/node-int64#readme
-License text: 290
+License text: 301
 
 node-releases 2.0.38
 License: MIT
 Homepage: https://github.com/chicoxyzzy/node-releases#readme
-License text: 291
+License text: 302
 
 nopt 9.0.0
 License: ISC
@@ -3001,7 +3001,7 @@ License text: 29
 normalize-path 3.0.0
 License: MIT
 Homepage: https://github.com/jonschlinkert/normalize-path
-License text: 292
+License text: 303
 
 normalize-url 6.1.0
 License: MIT
@@ -3011,42 +3011,42 @@ License text: 1
 object-assign 4.1.1
 License: MIT
 Homepage: https://github.com/sindresorhus/object-assign#readme
-License text: 83
+License text: 85
 
 object-hash 3.0.0
 License: MIT
 Homepage: https://github.com/puleos/object-hash
-License text: 293
+License text: 304
 
 object-inspect 1.13.4
 License: MIT
 Homepage: https://github.com/inspect-js/object-inspect
-License text: 294
+License text: 305
 
 object-keys 1.1.1
 License: MIT
 Homepage: https://github.com/ljharb/object-keys#readme
-License text: 295
+License text: 306
 
 object.assign 4.1.7
 License: MIT
 Homepage: https://github.com/ljharb/object.assign#readme
-License text: 296
+License text: 307
 
 object.fromentries 2.0.8
 License: MIT
 Homepage: https://github.com/es-shims/Object.fromEntries#readme
-License text: 238
+License text: 246
 
 object.values 1.2.1
 License: MIT
 Homepage: https://github.com/es-shims/Object.values#readme
-License text: 178
+License text: 184
 
 obug 2.1.4
 License: MIT
 Homepage: https://github.com/sxzz/obug#readme
-License text: 297
+License text: 308
 
 once 1.4.0
 License: ISC
@@ -3056,12 +3056,12 @@ License text: 29
 optionator 0.9.4
 License: MIT
 Homepage: https://github.com/gkz/optionator
-License text: 262
+License text: 271
 
 own-keys 1.0.1
 License: MIT
 Homepage: https://github.com/ljharb/own-keys#readme
-License text: 107
+License text: 109
 
 p-cancelable 2.1.1
 License: MIT
@@ -3071,22 +3071,22 @@ License text: 1
 p-limit 3.1.0
 License: MIT
 Homepage: https://github.com/sindresorhus/p-limit#readme
-License text: 52
+License text: 53
 
 p-locate 5.0.0
 License: MIT
 Homepage: https://github.com/sindresorhus/p-locate#readme
-License text: 52
+License text: 53
 
 package-manager-detector 1.6.0
 License: MIT
 Homepage: https://github.com/antfu-collective/package-manager-detector#readme
-License text: 298
+License text: 309
 
 pako 1.0.11
 License: (MIT AND Zlib)
 Homepage: https://github.com/nodeca/pako
-License text: 299
+License text: 310
 
 parent-module 1.0.1
 License: MIT
@@ -3096,12 +3096,12 @@ License text: 1
 parse5 8.0.1
 License: MIT
 Homepage: https://parse5.js.org
-License text: 300
+License text: 311
 
 path-data-parser 0.1.0
 License: MIT
 Homepage: https://github.com/pshihn/path-data-parser#readme
-License text: 301
+License text: 312
 
 path-exists 4.0.0
 License: MIT
@@ -3111,7 +3111,7 @@ License text: 1
 path-is-absolute 1.0.1
 License: MIT
 Homepage: https://github.com/sindresorhus/path-is-absolute#readme
-License text: 83
+License text: 85
 
 path-key 3.1.1
 License: MIT
@@ -3121,42 +3121,42 @@ License text: 1
 path-parse 1.0.7
 License: MIT
 Homepage: https://github.com/jbgutierrez/path-parse#readme
-License text: 302
+License text: 313
 
 pathe 2.0.3
 License: MIT
 Homepage: https://github.com/unjs/pathe#readme
-License text: 303
+License text: 314
 
 pe-library 0.4.1
 License: MIT
 Homepage: https://github.com/jet2jet/pe-library-js
-License text: 304
+License text: 315
 
 picocolors 1.1.1
 License: ISC
 Homepage: https://github.com/alexeyraspopov/picocolors#readme
-License text: 305
+License text: 316
 
 picomatch 2.3.2, 4.0.4, 4.0.5
 License: MIT
 Homepage: https://github.com/micromatch/picomatch
-License text: 306
+License text: 317
 
 pify 2.3.0
 License: MIT
 Homepage: https://github.com/sindresorhus/pify#readme
-License text: 83
+License text: 85
 
 pirates 4.0.7
 License: MIT
 Homepage: https://github.com/danez/pirates#readme
-License text: 307
+License text: 318
 
 pkijs 3.4.0
 License: BSD-3-Clause
 Homepage: https://github.com/PeculiarVentures/PKI.js#readme
-License text: 308
+License text: 319
 
 playwright 1.59.1
 License: Apache-2.0
@@ -3171,122 +3171,122 @@ License text: 47, 48
 plist 3.1.0, 3.1.1
 License: MIT
 Homepage: https://github.com/TooTallNate/node-plist#readme
-License text: 309
+License text: 320
 
 points-on-curve 0.2.0
 License: MIT
 Homepage: https://github.com/pshihn/bezier-points#readme
-License text: 301
+License text: 312
 
 points-on-path 0.2.1
 License: MIT
 Homepage: https://github.com/pshihn/points-on-path#readme
-License text: 310
+License text: 321
 
 possible-typed-array-names 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/possible-typed-array-names#readme
-License text: 107
+License text: 109
 
 postcss 8.5.23
 License: MIT
 Homepage: https://postcss.org/
-License text: 87
+License text: 89
 
 postcss-import 15.1.0
 License: MIT
 Homepage: https://github.com/postcss/postcss-import#readme
-License text: 311
+License text: 322
 
 postcss-js 4.1.0
 License: MIT
 Homepage: https://github.com/postcss/postcss-js#readme
-License text: 312
+License text: 323
 
 postcss-load-config 6.0.1
 License: MIT
 Homepage: https://github.com/postcss/postcss-load-config#readme
-License text: 313
+License text: 324
 
 postcss-nested 6.2.0
 License: MIT
 Homepage: https://github.com/postcss/postcss-nested#readme
-License text: 314
+License text: 325
 
 postcss-selector-parser 6.1.2
 License: MIT
 Homepage: https://github.com/postcss/postcss-selector-parser
-License text: 315
+License text: 326
 
 postcss-value-parser 4.2.0
 License: MIT
 Homepage: https://github.com/TrySound/postcss-value-parser
-License text: 316
+License text: 327
 
 prelude-ls 1.2.1
 License: MIT
 Homepage: http://preludels.com
-License text: 262
+License text: 271
 
 proc-log 6.1.0
 License: ISC
 Homepage: https://github.com/npm/proc-log#readme
-License text: 317
+License text: 328
 
 process-nextick-args 2.0.1
 License: MIT
 Homepage: https://github.com/calvinmetcalf/process-nextick-args
-License text: 318
+License text: 329
 
 progress 2.0.3
 License: MIT
 Homepage: https://github.com/visionmedia/node-progress#readme
-License text: 319
+License text: 330
 
 promise-retry 2.0.1
 License: MIT
 Homepage: https://github.com/IndigoUnited/node-promise-retry#readme
-License text: 320
+License text: 331
 
 prop-types 15.8.1
 License: MIT
 Homepage: https://facebook.github.io/react/
-License text: 321
+License text: 332
 
 proper-lockfile 4.1.2
 License: MIT
 Homepage: https://github.com/moxystudio/node-proper-lockfile
-License text: 126
+License text: 129
 
 proxy-from-env 2.1.0
 License: MIT
 Homepage: https://github.com/Rob--W/proxy-from-env#readme
-License text: 322
+License text: 333
 
 pump 3.0.4
 License: MIT
 Homepage: https://github.com/mafintosh/pump#readme
-License text: 173
+License text: 179
 
 punycode 2.3.1
 License: MIT
 Homepage: https://mths.be/punycode
-License text: 128
+License text: 131
 
 pvtsutils 1.3.6
 License: MIT
 Homepage: https://github.com/PeculiarVentures/pvtsutils#readme
-License text: 323
+License text: 334
 
 pvutils 1.1.5
 License: MIT
 Homepage: https://github.com/PeculiarVentures/pvutils#readme
-License text: 324
+License text: 335
 
 queue-microtask 1.2.3
 License: MIT
 Homepage: https://github.com/feross/queue-microtask
-License text: 325
+License text: 336
 
 quick-lru 5.1.1
 License: MIT
@@ -3301,47 +3301,47 @@ License text: 49
 react 19.2.5
 License: MIT
 Homepage: https://react.dev/
-License text: 326
+License text: 337
 
 react-dnd 16.0.1
 License: MIT
 Homepage: https://github.com/react-dnd/react-dnd#readme
-License text: 327
+License text: 338
 
 react-dnd-html5-backend 16.0.1
 License: MIT
 Homepage: https://github.com/react-dnd/react-dnd#readme
-License text: 160
+License text: 166
 
 react-dom 19.2.5
 License: MIT
 Homepage: https://react.dev/
-License text: 326
+License text: 337
 
 react-hammerjs 1.0.1
 License: MIT
 Homepage: https://github.com/JedWatson/react-hammerjs#readme
-License text: 328
+License text: 339
 
 react-hotkeys-hook 5.3.2
 License: MIT
 Homepage: https://react-hotkeys-hook.vercel.app/
-License text: 329
+License text: 340
 
 react-i18next 17.0.8
 License: MIT
 Homepage: https://github.com/i18next/react-i18next
-License text: 330
+License text: 341
 
 react-is 16.13.1
 License: MIT
 Homepage: https://reactjs.org/
-License text: 181
+License text: 187
 
 react-remove-scroll 2.7.2
 License: MIT
 Homepage: https://github.com/theKashey/react-remove-scroll#readme
-License text: 73
+License text: 75
 
 react-remove-scroll-bar 2.3.8
 License: MIT
@@ -3351,12 +3351,12 @@ License text: not present in the installed package
 react-style-singleton 2.2.3
 License: MIT
 Homepage: https://github.com/theKashey/react-style-singleton#readme
-License text: 73
+License text: 75
 
 react-textarea-autosize 8.5.3
 License: MIT
 Homepage: https://github.com/Andarist/react-textarea-autosize#readme
-License text: 331
+License text: 342
 
 read-binary-file-arch 1.0.6
 License: MIT
@@ -3366,57 +3366,57 @@ License text: not present in the installed package
 read-cache 1.0.0
 License: MIT
 Homepage: https://github.com/TrySound/read-cache#readme
-License text: 332
+License text: 343
 
 readable-stream 2.3.8
 License: MIT
 Homepage: https://github.com/nodejs/readable-stream#readme
-License text: 333
+License text: 344
 
 readdirp 3.6.0, 4.1.2
 License: MIT
 Homepage: https://github.com/paulmillr/readdirp
-License text: 334
+License text: 345
 
 redux 4.2.1
 License: MIT
 Homepage: http://redux.js.org
-License text: 335
+License text: 346
 
 reflect.getprototypeof 1.0.10
 License: MIT
 Homepage: https://github.com/es-shims/Reflect.getPrototypeOf
-License text: 336
+License text: 347
 
 regexp.prototype.flags 1.5.4
 License: MIT
 Homepage: https://github.com/es-shims/RegExp.prototype.flags#readme
-License text: 337
+License text: 348
 
 require-directory 2.1.1
 License: MIT
 Homepage: https://github.com/troygoode/node-require-directory/
-License text: 338
+License text: 349
 
 require-from-string 2.0.2
 License: MIT
 Homepage: https://github.com/floatdrop/require-from-string#readme
-License text: 339
+License text: 350
 
 resedit 1.7.2
 License: MIT
 Homepage: https://github.com/jet2jet/resedit-js
-License text: 304
+License text: 315
 
 resolve 1.22.12
 License: MIT
 Homepage: https://github.com/browserify/resolve#readme
-License text: 340
+License text: 351
 
 resolve-alpn 1.2.1
 License: MIT
 Homepage: https://github.com/szmarczak/resolve-alpn#readme
-License text: 54
+License text: 55
 
 resolve-from 4.0.0
 License: MIT
@@ -3426,17 +3426,17 @@ License text: 1
 responselike 2.0.1
 License: MIT
 Homepage: https://github.com/sindresorhus/responselike#readme
-License text: 341
+License text: 352
 
 retry 0.12.0
 License: MIT
 Homepage: https://github.com/tim-kos/node-retry
-License text: 342
+License text: 353
 
 reusify 1.1.0
 License: MIT
 Homepage: https://github.com/mcollina/reusify#readme
-License text: 343
+License text: 354
 
 rimraf 2.6.3, 3.0.2
 License: ISC
@@ -3446,7 +3446,7 @@ License text: 29
 robust-predicates 3.0.3
 License: Unlicense
 Homepage: https://github.com/mourner/robust-predicates#readme
-License text: 344
+License text: 355
 
 rolldown 1.1.5
 License: MIT
@@ -3456,57 +3456,57 @@ License text: 51
 roughjs 4.6.6
 License: MIT
 Homepage: https://roughjs.com
-License text: 345
+License text: 356
 
 run-parallel 1.2.0
 License: MIT
 Homepage: https://github.com/feross/run-parallel
-License text: 325
+License text: 336
 
 rw 1.3.3
 License: BSD-3-Clause
 Homepage: https://github.com/mbostock/rw
-License text: 346
+License text: 357
 
 safe-array-concat 1.1.4
 License: MIT
 Homepage: https://github.com/ljharb/safe-array-concat#readme
-License text: 150
+License text: 156
 
 safe-buffer 5.1.2
 License: MIT
 Homepage: https://github.com/feross/safe-buffer
-License text: 347
+License text: 358
 
 safe-push-apply 1.0.0
 License: MIT
 Homepage: https://github.com/ljharb/safe-push-apply#readme
-License text: 107
+License text: 109
 
 safe-regex-test 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/safe-regex-test#readme
-License text: 177
+License text: 183
 
 safer-buffer 2.1.2
 License: MIT
 Homepage: https://github.com/ChALkeR/safer-buffer#readme
-License text: 348
+License text: 359
 
 sanitize-filename 1.6.4
 License: WTFPL OR ISC
 Homepage: https://github.com/parshap/node-sanitize-filename#readme
-License text: 349
+License text: 360
 
 sass 1.99.0
 License: MIT
 Homepage: https://github.com/sass/dart-sass
-License text: 350
+License text: 361
 
 sax 1.6.0
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/sax-js#readme
-License text: 282
+License text: 257
 
 saxes 6.0.0
 License: ISC
@@ -3516,12 +3516,12 @@ License text: not present in the installed package
 scheduler 0.27.0
 License: MIT
 Homepage: https://react.dev/
-License text: 326
+License text: 337
 
 scroller 0.0.3
 License: MIT
 Homepage: https://github.com/popham/scroller
-License text: 351
+License text: 362
 
 semver 5.7.2, 6.3.1, 7.7.4
 License: ISC
@@ -3531,27 +3531,27 @@ License text: 29
 set-function-length 1.2.2
 License: MIT
 Homepage: https://github.com/ljharb/set-function-length#readme
-License text: 222
+License text: 230
 
 set-function-name 2.0.2
 License: MIT
 Homepage: https://github.com/ljharb/set-function-name#readme
-License text: 222
+License text: 230
 
 set-proto 1.0.0
 License: MIT
 Homepage: https://github.com/ljharb/set-proto#readme
-License text: 107
+License text: 109
 
 setimmediate 1.0.5
 License: MIT
 Homepage: https://github.com/YuzuJS/setImmediate#readme
-License text: 352
+License text: 363
 
 shebang-command 2.0.0
 License: MIT
 Homepage: https://github.com/kevva/shebang-command#readme
-License text: 353
+License text: 364
 
 shebang-regex 3.0.0
 License: MIT
@@ -3561,57 +3561,57 @@ License text: 1
 side-channel 1.1.1
 License: MIT
 Homepage: https://github.com/ljharb/side-channel#readme
-License text: 208
+License text: 215
 
 side-channel-list 1.0.1
 License: MIT
 Homepage: https://github.com/ljharb/side-channel-list#readme
-License text: 107
+License text: 109
 
 side-channel-map 1.0.1
 License: MIT
 Homepage: https://github.com/ljharb/side-channel-map#readme
-License text: 107
+License text: 109
 
 side-channel-weakmap 1.0.2
 License: MIT
 Homepage: https://github.com/ljharb/side-channel-weakmap#readme
-License text: 208
+License text: 215
 
 siginfo 2.0.0
 License: ISC
 Homepage: https://github.com/emilbayes/siginfo#readme
-License text: 354
+License text: 365
 
 signal-exit 3.0.7
 License: ISC
 Homepage: https://github.com/tapjs/signal-exit
-License text: 355
+License text: 366
 
 simple-update-notifier 2.0.0
 License: MIT
 Homepage: https://github.com/alexbrazier/simple-update-notifier.git
-License text: 356
+License text: 367
 
 sonner 2.0.7
 License: MIT
 Homepage: https://sonner.emilkowal.ski/
-License text: 357
+License text: 368
 
 source-map 0.6.1
 License: BSD-3-Clause
 Homepage: https://github.com/mozilla/source-map
-License text: 358
+License text: 369
 
 source-map-js 1.2.1
 License: BSD-3-Clause
 Homepage: https://github.com/7rulnik/source-map-js
-License text: 358
+License text: 369
 
 source-map-support 0.5.21
 License: MIT
 Homepage: https://github.com/evanw/node-source-map-support#readme
-License text: 359
+License text: 370
 
 stackback 0.0.2
 License: MIT
@@ -3621,22 +3621,17 @@ License text: not present in the installed package
 stat-mode 1.0.0
 License: MIT
 Homepage: https://github.com/TooTallNate/stat-mode
-License text: 360
+License text: 371
 
 std-env 4.2.0
 License: MIT
 Homepage: https://github.com/unjs/std-env#readme
-License text: 249
+License text: 258
 
 stop-iteration-iterator 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/stop-iteration-iterator#readme
-License text: 150
-
-string_decoder 1.1.1
-License: MIT
-Homepage: https://github.com/nodejs/string_decoder
-License text: 333
+License text: 156
 
 string-width 4.2.3
 License: MIT
@@ -3646,22 +3641,27 @@ License text: 1
 string.prototype.includes 2.0.1
 License: MIT
 Homepage: https://mths.be/includes
-License text: 128
+License text: 131
 
 string.prototype.trim 1.2.11
 License: MIT
 Homepage: https://github.com/es-shims/String.prototype.trim#readme
-License text: 178
+License text: 184
 
 string.prototype.trimend 1.0.10
 License: MIT
 Homepage: https://github.com/es-shims/String.prototype.trimEnd#readme
-License text: 361
+License text: 372
 
 string.prototype.trimstart 1.0.8
 License: MIT
 Homepage: https://github.com/es-shims/String.prototype.trimStart#readme
-License text: 361
+License text: 372
+
+string_decoder 1.1.1
+License: MIT
+Homepage: https://github.com/nodejs/string_decoder
+License text: 344
 
 strip-ansi 6.0.1
 License: MIT
@@ -3671,22 +3671,22 @@ License text: 1
 strip-json-comments 3.1.1
 License: MIT
 Homepage: https://github.com/sindresorhus/strip-json-comments#readme
-License text: 52
+License text: 53
 
 style-mod 4.1.3
 License: MIT
 Homepage: https://github.com/marijnh/style-mod#readme
-License text: 362
+License text: 373
 
 stylis 4.4.0
 License: MIT
 Homepage: https://github.com/thysultan/stylis.js
-License text: 363
+License text: 374
 
 sucrase 3.35.1
 License: MIT
 Homepage: https://github.com/alangpierce/sucrase#readme
-License text: 364
+License text: 375
 
 sumchecker 3.0.1
 License: Apache-2.0
@@ -3701,36 +3701,36 @@ License text: 1
 supports-preserve-symlinks-flag 1.0.0
 License: MIT
 Homepage: https://github.com/inspect-js/node-supports-preserve-symlinks-flag#readme
-License text: 220
+License text: 228
 
 symbol-tree 3.2.4
 License: MIT
 Homepage: https://github.com/jsdom/js-symbol-tree#symbol-tree
-License text: 365
+License text: 376
 
 tailwind-merge 3.5.0
 License: MIT
 Homepage: https://github.com/dcastil/tailwind-merge
-License text: 366
+License text: 377
 
 tailwindcss 3.4.19
 License: MIT
 Homepage: https://tailwindcss.com
-License text: 367
+License text: 378
 
 tailwindcss-animate 1.0.7
 License: MIT
-License text: 368
+License text: 379
 
 tar 7.5.20
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/node-tar#readme
-License text: 282
+License text: 257
 
 temp 0.9.4
 License: MIT
 Homepage: https://github.com/bruce/node-temp#readme
-License text: 369
+License text: 380
 
 temp-file 3.4.0
 License: MIT
@@ -3740,62 +3740,62 @@ License text: not present in the installed package
 text-table 0.2.0
 License: MIT
 Homepage: https://github.com/substack/text-table
-License text: 255
+License text: 264
 
 thenify 3.3.1
 License: MIT
 Homepage: https://github.com/thenables/thenify#readme
-License text: 370
+License text: 381
 
 thenify-all 1.6.0
 License: MIT
 Homepage: https://github.com/thenables/thenify-all#readme
-License text: 371
+License text: 382
 
 tiny-async-pool 1.3.0
 License: MIT
 Homepage: https://github.com/rxaviers/async-pool#readme
-License text: 372
+License text: 383
 
 tiny-typed-emitter 2.1.0
 License: MIT
 Homepage: https://github.com/binier/tiny-typed-emitter#readme
-License text: 373
+License text: 384
 
 tinybench 2.9.0
 License: MIT
 Homepage: https://github.com/tinylibs/tinybench#readme
-License text: 374
+License text: 385
 
 tinyexec 1.2.4
 License: MIT
 Homepage: https://github.com/tinylibs/tinyexec#readme
-License text: 375
+License text: 386
 
 tinyglobby 0.2.16, 0.2.17
 License: MIT
 Homepage: https://superchupu.dev/tinyglobby
-License text: 376
+License text: 387
 
 tinyrainbow 3.1.0
 License: MIT
 Homepage: https://github.com/tinylibs/tinyrainbow#readme
-License text: 374
+License text: 385
 
 tldts 7.4.9
 License: MIT
 Homepage: https://github.com/remusao/tldts#readme
-License text: 377
+License text: 388
 
 tldts-core 7.4.9
 License: MIT
 Homepage: https://github.com/remusao/tldts#readme
-License text: 377
+License text: 388
 
 tmp 0.2.7
 License: MIT
 Homepage: http://github.com/raszi/node-tmp
-License text: 378
+License text: 389
 
 tmp-promise 3.0.3
 License: MIT
@@ -3805,17 +3805,17 @@ License text: not present in the installed package
 to-regex-range 5.0.1
 License: MIT
 Homepage: https://github.com/micromatch/to-regex-range
-License text: 379
+License text: 390
 
 tough-cookie 6.0.2
 License: BSD-3-Clause
 Homepage: https://github.com/salesforce/tough-cookie
-License text: 380
+License text: 391
 
 tr46 6.0.0
 License: MIT
 Homepage: https://github.com/jsdom/tr46#readme
-License text: 381
+License text: 392
 
 truncate-utf8-bytes 1.0.2
 License: WTFPL
@@ -3825,107 +3825,107 @@ License text: not present in the installed package
 ts-api-utils 2.5.0
 License: MIT
 Homepage: https://github.com/JoshuaKGoldberg/ts-api-utils#readme
-License text: 382
+License text: 393
 
 ts-dedent 2.2.0
 License: MIT
 Homepage: https://github.com/tamino-martinius/node-ts-dedent#readme
-License text: 383
+License text: 394
 
 ts-interface-checker 0.1.13
 License: Apache-2.0
 Homepage: https://github.com/gristlabs/ts-interface-checker#readme
-License text: 156
+License text: 162
 
 ts-key-enum 2.0.12
 License: MIT
 Homepage: https://gitlab.com/nfriend/ts-key-enum#readme
-License text: 384
+License text: 395
 
 ts-keycode-enum 1.0.6
 License: MIT
 Homepage: https://github.com/nfriend/ts-keycode-enum#readme
-License text: 385
+License text: 396
 
 tslib 2.8.1
 License: 0BSD
 Homepage: https://www.typescriptlang.org/
-License text: 386
+License text: 397
 
 type-check 0.4.0
 License: MIT
 Homepage: https://github.com/gkz/type-check
-License text: 262
+License text: 271
 
 type-fest 0.20.2
 License: (MIT OR CC0-1.0)
 Homepage: https://github.com/sindresorhus/type-fest#readme
-License text: 387
+License text: 398
 
 typed-array-buffer 1.0.3
 License: MIT
 Homepage: https://github.com/inspect-js/typed-array-buffer#readme
-License text: 150
+License text: 156
 
 typed-array-byte-length 1.0.3
 License: MIT
 Homepage: https://github.com/inspect-js/typed-array-byte-length#readme
-License text: 88
+License text: 90
 
 typed-array-byte-offset 1.0.4
 License: MIT
 Homepage: https://github.com/inspect-js/typed-array-byte-offset#readme
-License text: 88
+License text: 90
 
 typed-array-length 1.0.8
 License: MIT
 Homepage: https://github.com/inspect-js/typed-array-length#readme
-License text: 88
+License text: 90
 
 typescript 6.0.3
 License: Apache-2.0
 Homepage: https://www.typescriptlang.org/
-License text: 388
+License text: 399
 
 unbox-primitive 1.1.0
 License: MIT
 Homepage: https://github.com/ljharb/unbox-primitive#readme
-License text: 208
+License text: 215
 
 undici 6.27.0, 7.28.0
 License: MIT
 Homepage: https://undici.nodejs.org
-License text: 389
+License text: 400
 
 undici-types 6.21.0, 7.18.2, 7.24.6, 8.3.0
 License: MIT
 Homepage: https://undici.nodejs.org
-License text: 389
+License text: 400
 
 universalify 0.1.2, 2.0.1
 License: MIT
 Homepage: https://github.com/RyanZim/universalify#readme
-License text: 390
+License text: 401
 
 unzipper 0.12.5
 License: MIT
 Homepage: https://github.com/ZJONSSON/node-unzipper#readme
-License text: 391
+License text: 402
 
 update-browserslist-db 1.2.3
 License: MIT
 Homepage: https://github.com/browserslist/update-db#readme
-License text: 392
+License text: 403
 
 uri-js 4.4.1
 License: BSD-2-Clause
 Homepage: https://github.com/garycourt/uri-js
-License text: 393
+License text: 404
 
 use-callback-ref 1.3.3
 License: MIT
 Homepage: https://github.com/theKashey/use-callback-ref#readme
-License text: 73
+License text: 75
 
 use-composed-ref 1.4.0
 License: MIT
@@ -3935,87 +3935,87 @@ License text: not present in the installed package
 use-isomorphic-layout-effect 1.2.1
 License: MIT
 Homepage: https://github.com/Andarist/use-isomorphic-layout-effect#readme
-License text: 394
+License text: 405
 
 use-latest 1.3.0
 License: MIT
 Homepage: https://github.com/Andarist/use-latest#readme
-License text: 395
+License text: 406
 
 use-sidecar 1.1.3
 License: MIT
 Homepage: https://github.com/theKashey/use-sidecar
-License text: 73
+License text: 75
 
 use-sync-external-store 1.6.0
 License: MIT
 Homepage: https://github.com/facebook/react#readme
-License text: 326
+License text: 337
 
 utf8-byte-length 1.0.5
 License: (WTFPL OR MIT)
 Homepage: https://github.com/parshap/utf8-byte-length#readme
-License text: 396, 397
+License text: 407, 408
 
 util-deprecate 1.0.2
 License: MIT
 Homepage: https://github.com/TooTallNate/util-deprecate
-License text: 398
+License text: 409
 
 uuid 14.0.0
 License: MIT
 Homepage: https://github.com/uuidjs/uuid#readme
-License text: 399
+License text: 410
 
 vaul 1.1.2
 License: MIT
 Homepage: https://vaul.emilkowal.ski/
-License text: 400
+License text: 411
 
 vite 8.1.5
 License: MIT
 Homepage: https://vite.dev
-License text: 401
+License text: 412
 
 vitest 4.1.10
 License: MIT
 Homepage: https://vitest.dev
-License text: 402
+License text: 413
 
 void-elements 3.1.0
 License: MIT
 Homepage: https://github.com/jadejs/void-elements
-License text: 403
+License text: 414
 
 w3c-keyname 2.2.8
 License: MIT
 Homepage: https://github.com/marijnh/w3c-keyname#readme
-License text: 404
+License text: 415
 
 w3c-xmlserializer 5.0.0
 License: MIT
 Homepage: https://github.com/jsdom/w3c-xmlserializer#readme
-License text: 405
+License text: 416
 
 webcrypto-core 1.9.2
 License: MIT
 Homepage: https://github.com/PeculiarVentures/webcrypto-core#readme
-License text: 406
+License text: 417
 
 webidl-conversions 8.0.1
 License: BSD-2-Clause
 Homepage: https://github.com/jsdom/webidl-conversions#readme
-License text: 407
+License text: 418
 
 whatwg-mimetype 5.0.0
 License: MIT
 Homepage: https://github.com/jsdom/whatwg-mimetype#readme
-License text: 149
+License text: 155
 
 whatwg-url 16.0.1
 License: MIT
 Homepage: https://github.com/jsdom/whatwg-url#readme
-License text: 408
+License text: 419
 
 which 2.0.2, 5.0.0, 6.0.1
 License: ISC
@@ -4025,37 +4025,37 @@ License text: 29
 which-boxed-primitive 1.1.1
 License: MIT
 Homepage: https://github.com/inspect-js/which-boxed-primitive#readme
-License text: 208
+License text: 215
 
 which-builtin-type 1.2.1
 License: MIT
 Homepage: https://github.com/inspect-js/which-builtin-type#readme
-License text: 409
+License text: 420
 
 which-collection 1.0.2
 License: MIT
 Homepage: https://github.com/inspect-js/which-collection#readme
-License text: 246
+License text: 254
 
 which-typed-array 1.1.22
 License: MIT
 Homepage: https://github.com/inspect-js/which-typed-array#readme
-License text: 178
+License text: 184
 
 why-is-node-running 2.3.0
 License: MIT
 Homepage: https://github.com/mafintosh/why-is-node-running
-License text: 410
+License text: 421
 
 word-wrap 1.2.5
 License: MIT
 Homepage: https://github.com/jonschlinkert/word-wrap
-License text: 243
+License text: 251
 
 wrap-ansi 7.0.0
 License: MIT
 Homepage: https://github.com/chalk/wrap-ansi#readme
-License text: 52
+License text: 53
 
 wrappy 1.0.2
 License: ISC
@@ -4065,32 +4065,32 @@ License text: 29
 xml 1.0.1
 License: MIT
 Homepage: http://github.com/dylang/node-xml
-License text: 411
+License text: 422
 
 xml-js 1.6.11
 License: MIT
 Homepage: https://github.com/nashwaan/xml-js#readme
-License text: 412
+License text: 423
 
 xml-name-validator 5.0.0
 License: Apache-2.0
 Homepage: https://github.com/jsdom/xml-name-validator#readme
-License text: 413
+License text: 424
 
 xmlbuilder 15.1.1
 License: MIT
 Homepage: http://github.com/oozcitak/xmlbuilder-js
-License text: 414
+License text: 425
 
 xmlchars 2.2.0
 License: MIT
 Homepage: https://github.com/lddubeau/xmlchars#readme
-License text: 415
+License text: 426
 
 y18n 5.0.8
 License: ISC
 Homepage: https://github.com/yargs/y18n
-License text: 416
+License text: 427
 
 yallist 4.0.0
 License: ISC
@@ -4100,27 +4100,27 @@ License text: 29
 yallist 5.0.0
 License: BlueOak-1.0.0
 Homepage: https://github.com/isaacs/yallist#readme
-License text: 29
+License text: 115
 
 yargs 17.7.2
 License: MIT
 Homepage: https://yargs.js.org/
-License text: 417
+License text: 428
 
 yargs-parser 21.1.1
 License: ISC
 Homepage: https://github.com/yargs/yargs-parser#readme
-License text: 418
+License text: 429
 
 yocto-queue 0.1.0
 License: MIT
 Homepage: https://github.com/sindresorhus/yocto-queue#readme
-License text: 52
+License text: 53
 
 zod 4.1.13
 License: MIT
 Homepage: https://zod.dev
-License text: 419
+License text: 430
 
 ================================================================================
 
@@ -5039,7 +5039,7 @@ SOFTWARE.
 ================================================================================
 
 License text 29
-Packages: @isaacs/fs-minipass 4.0.1; isexe 2.0.0; isexe 3.1.5, 4.0.0; minimatch 10.2.5; minimatch 3.1.5, 5.1.9, 9.0.9; nopt 9.0.0; once 1.4.0; rimraf 2.6.3, 3.0.2; semver 5.7.2, 6.3.1, 7.7.4; which 2.0.2, 5.0.0, 6.0.1; wrappy 1.0.2; yallist 4.0.0; yallist 5.0.0
+Packages: @isaacs/fs-minipass 4.0.1; isexe 2.0.0; lru-cache 6.0.0, 10.2.0; minimatch 3.1.5, 5.1.9, 9.0.9; nopt 9.0.0; once 1.4.0; rimraf 2.6.3, 3.0.2; semver 5.7.2, 6.3.1, 7.7.4; which 2.0.2, 5.0.0, 6.0.1; wrappy 1.0.2; yallist 4.0.0
 
 The ISC License
 
@@ -5402,7 +5402,7 @@ Packages: @peculiar/asn1-schema 2.8.0
 
 MIT License
 
-Copyright (c) 2020 
+Copyright (c) 2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -5429,7 +5429,7 @@ Packages: @peculiar/json-schema 1.1.12
 
 MIT License
 
-Copyright (c) 2018 
+Copyright (c) 2018
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -5808,7 +5808,34 @@ The licenses of externally maintained libraries from which parts of the Software
 ================================================================================
 
 License text 52
-Packages: @sindresorhus/is 4.6.0; decompress-response 6.0.0; escape-string-regexp 4.0.0; find-up 5.0.0; get-stream 5.2.0; globals 13.24.0; import-fresh 3.3.1; locate-path 6.0.0; p-limit 3.1.0; p-locate 5.0.0; strip-json-comments 3.1.1; wrap-ansi 7.0.0; yocto-queue 0.1.0
+Packages: @rolldown/pluginutils 1.0.0-rc.7, 1.0.1
+
+MIT License
+
+Copyright (c) 2026-present, rolldown/plugins repository contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
+License text 53
+Packages: @sindresorhus/is 4.6.0; decompress-response 6.0.0; env-paths 2.2.1, 3.0.0; escape-string-regexp 4.0.0; find-up 5.0.0; get-stream 5.2.0; globals 13.24.0; import-fresh 3.3.1; locate-path 6.0.0; mimic-response 1.0.1, 3.1.0; p-limit 3.1.0; p-locate 5.0.0; strip-json-comments 3.1.1; wrap-ansi 7.0.0; yocto-queue 0.1.0
 
 MIT License
 
@@ -5822,7 +5849,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 53
+License text 54
 Packages: @standard-schema/spec 1.1.0
 
 MIT License
@@ -5849,7 +5876,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 54
+License text 55
 Packages: @szmarczak/http-timer 4.0.6; defer-to-connect 2.0.1; http2-wrapper 1.0.3; resolve-alpn 1.2.1
 
 MIT License
@@ -5876,7 +5903,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 55
+License text 56
 Packages: @types/cacheable-request 6.0.3; @types/chai 5.2.3; @types/d3 7.4.3; @types/d3-array 3.2.2; @types/d3-axis 3.0.6; @types/d3-brush 3.0.6; @types/d3-chord 3.0.6; @types/d3-color 3.1.3; @types/d3-contour 3.0.6; @types/d3-delaunay 6.0.4; @types/d3-dispatch 3.0.7; @types/d3-drag 3.0.7; @types/d3-dsv 3.0.7; @types/d3-ease 3.0.2; @types/d3-fetch 3.0.7; @types/d3-force 3.0.10; @types/d3-format 3.0.4; @types/d3-geo 3.1.0; @types/d3-hierarchy 3.1.7; @types/d3-interpolate 3.0.4; @types/d3-path 3.1.1; @types/d3-polygon 3.0.2; @types/d3-quadtree 3.0.6; @types/d3-random 3.0.3; @types/d3-scale 4.0.9; @types/d3-scale-chromatic 3.1.0; @types/d3-selection 3.0.11; @types/d3-shape 3.1.8; @types/d3-time 3.0.4; @types/d3-time-format 4.0.3; @types/d3-timer 3.0.2; @types/d3-transition 3.0.9; @types/d3-zoom 3.0.8; @types/debug 4.1.13; @types/deep-eql 4.0.2; @types/estree 1.0.8; @types/fs-extra 9.0.13; @types/geojson 7946.0.16; @types/hammerjs 2.0.46; @types/http-cache-semantics 4.2.0; @types/keyv 3.1.4; @types/lodash 4.17.24; @types/lodash-es 4.17.12; @types/ms 2.1.0; @types/node 22.20.1, 24.13.3, 25.9.3, 26.1.1; @types/react 19.2.14; @types/react-dom 19.2.3; @types/responselike 1.0.3; @types/scroller 0.1.5
 
 MIT License
@@ -5903,7 +5930,7 @@ MIT License
 
 ================================================================================
 
-License text 56
+License text 57
 Packages: @typescript-eslint/eslint-plugin 8.61.0; @typescript-eslint/parser 8.61.0; @typescript-eslint/scope-manager 8.61.0; @typescript-eslint/types 8.61.0; @typescript-eslint/typescript-estree 8.61.0; @typescript-eslint/utils 8.61.0; @typescript-eslint/visitor-keys 8.61.0
 
 MIT License
@@ -5930,7 +5957,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 57
+License text 58
 Packages: @typescript-eslint/project-service 8.61.0; @typescript-eslint/tsconfig-utils 8.61.0
 
 MIT License
@@ -5957,7 +5984,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 58
+License text 59
 Packages: @typescript-eslint/type-utils 8.61.0
 
 MIT License
@@ -5984,7 +6011,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 59
+License text 60
 Packages: @ungap/structured-clone 1.3.0
 
 ISC License
@@ -6005,7 +6032,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 60
+License text 61
 Packages: @upsetjs/venn.js 2.0.0
 
 MIT License
@@ -6033,7 +6060,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 61
+License text 62
 Packages: @vitejs/plugin-react 6.0.1
 
 MIT License
@@ -6060,7 +6087,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 62
+License text 63
 Packages: @vitest/expect 4.1.10; @vitest/mocker 4.1.10; @vitest/pretty-format 4.1.10; @vitest/runner 4.1.10; @vitest/snapshot 4.1.10; @vitest/spy 4.1.10; @vitest/utils 4.1.10
 
 MIT License
@@ -6087,7 +6114,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 63
+License text 64
 Packages: @xmldom/xmldom 0.8.13, 0.9.10
 
 Copyright 2019 - present Christopher J. Brody and other contributors, as listed in: https://github.com/xmldom/xmldom/graphs/contributors
@@ -6101,7 +6128,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 64
+License text 65
 Packages: abbrev 4.0.0
 
 This software is dual-licensed under the ISC and MIT licenses.
@@ -6153,7 +6180,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 65
+License text 66
 Packages: acorn 8.16.0
 
 MIT License
@@ -6180,7 +6207,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 66
+License text 67
 Packages: acorn-jsx 5.3.2
 
 Copyright (C) 2012-2017 by Ingvar Stepanyan
@@ -6205,8 +6232,8 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 67
-Packages: agent-base 6.0.2, 7.1.4; http-proxy-agent 7.0.2
+License text 68
+Packages: agent-base 6.0.2, 7.1.4; http-proxy-agent 7.0.2; https-proxy-agent 5.0.1, 7.0.6
 
 (The MIT License)
 
@@ -6233,7 +6260,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 68
+License text 69
 Packages: ajv 6.14.0, 8.20.0
 
 The MIT License (MIT)
@@ -6260,7 +6287,34 @@ SOFTWARE.
 
 ================================================================================
 
-License text 69
+License text 70
+Packages: ajv 6.14.0, 8.20.0
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2021 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
+License text 71
 Packages: any-promise 1.3.0
 
 Copyright (C) 2014-2016 Kevin Beaty
@@ -6285,7 +6339,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 70
+License text 72
 Packages: anymatch 3.1.3
 
 The ISC License
@@ -6306,7 +6360,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 71
+License text 73
 Packages: arg 5.0.2
 
 The MIT License (MIT)
@@ -6333,7 +6387,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 72
+License text 74
 Packages: argparse 2.0.1
 
 A. HISTORY OF THE SOFTWARE
@@ -6593,7 +6647,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 73
+License text 75
 Packages: aria-hidden 1.2.6; react-remove-scroll 2.7.2; react-style-singleton 2.2.3; use-callback-ref 1.3.3; use-sidecar 1.1.3
 
 MIT License
@@ -6620,7 +6674,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 74
+License text 76
 Packages: aria-query 5.3.2; axobject-query 4.1.0
 
 Apache License
@@ -6827,7 +6881,7 @@ limitations under the License.
 
 ================================================================================
 
-License text 75
+License text 77
 Packages: array-buffer-byte-length 1.0.2
 
 MIT License
@@ -6854,7 +6908,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 76
+License text 78
 Packages: array-includes 3.1.9; define-properties 1.2.1; es-abstract 1.24.2
 
 The MIT License (MIT)
@@ -6881,7 +6935,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 77
+License text 79
 Packages: array.prototype.flat 1.3.3; array.prototype.flatmap 1.3.3
 
 MIT License
@@ -6908,7 +6962,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 78
+License text 80
 Packages: arraybuffer.prototype.slice 1.0.4
 
 MIT License
@@ -6935,7 +6989,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 79
+License text 81
 Packages: asn1js 3.0.10
 
 Copyright (c) 2014, GMO GlobalSign
@@ -6971,7 +7025,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 80
+License text 82
 Packages: assertion-error 2.0.1
 
 MIT License
@@ -6998,7 +7052,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 81
+License text 83
 Packages: ast-types-flow 0.0.8
 
 MIT License
@@ -7025,7 +7079,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 82
+License text 84
 Packages: async 3.2.6
 
 Copyright (c) 2010-2018 Caolan McMahon
@@ -7050,7 +7104,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 83
+License text 85
 Packages: async-exit-hook 2.0.1; object-assign 4.1.1; path-is-absolute 1.0.1; pify 2.3.0
 
 The MIT License (MIT)
@@ -7077,7 +7131,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 84
+License text 86
 Packages: async-function 1.0.0
 
 MIT License
@@ -7104,7 +7158,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 85
+License text 87
 Packages: asynckit 0.4.0
 
 The MIT License (MIT)
@@ -7131,7 +7185,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 86
+License text 88
 Packages: at-least-node 1.0.0
 
 The ISC License
@@ -7143,7 +7197,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ================================================================================
 
-License text 87
+License text 89
 Packages: autoprefixer 10.5.0; postcss 8.5.23
 
 The MIT License (MIT)
@@ -7169,7 +7223,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 88
+License text 90
 Packages: available-typed-arrays 1.0.7; is-finalizationregistry 1.1.1; is-weakref 1.1.1; typed-array-byte-length 1.0.3; typed-array-byte-offset 1.0.4; typed-array-length 1.0.8
 
 MIT License
@@ -7196,7 +7250,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 89
+License text 91
 Packages: aws4 1.13.2
 
 Copyright 2013 Michael Hart (michael.hart.au@gmail.com)
@@ -7221,7 +7275,79 @@ SOFTWARE.
 
 ================================================================================
 
-License text 90
+License text 92
+Packages: axe-core 4.12.1
+
+-----------------------------------------------------------------------------
+                              MIT License
+  Applies to:
+  - colorjs.io; Copyright (c) 2021 Lea Verou, Chris Lilley
+  - core-js-pure; Copyright (c) 2014-2023 Denis Pushkarev
+  - css-selector-parser; Copyright (c) 2013 Dulin Marat
+  - doT.js; Copyright (c) 2011 Laura Doktorova
+      Software includes portions from jQote2 Copyright (c) 2010 aefxx,
+      http://aefxx.com/ licensed under the MIT license.
+  - emoji-regex; Copyright (c) Mathias Bynens <https://mathiasbynens.be/>
+  - es6-iterator; Copyright (c) 2013-2017 Mariusz Nowak (www.medikoo.com)
+  - es6-promise;
+      Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
+  - event-emitter; Copyright (C) 2012-2015 Mariusz Nowak (www.medikoo.com)
+  - is-promise; Copyright (c) 2014 Forbes Lindesay
+  - lru-queue; Copyright (C) 2014 Mariusz Nowak (www.medikoo.com)
+  - typedarray;
+      Copyright (c) 2010, Linden Research, Inc.
+      Copyright (c) 2012, Joshua Bell
+  - weakmap-polyfill; Copyright (c) 2015-2021 polygonplanet
+-----------------------------------------------------------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+-----------------------------------------------------------------------------
+                              ISC License
+  Applies to:
+  - d; Copyright (c) 2013-2019, Mariusz Nowak, @medikoo, medikoo.com
+  - es5-ext; Copyright (c) 2011-2022, Mariusz Nowak, @medikoo, medikoo.com
+  - es6-symbol; Copyright (c) 2013-2019, Mariusz Nowak, @medikoo, medikoo.com
+  - es6-weak-map; Copyright (c) 2013-2018, Mariusz Nowak, @medikoo, medikoo.com
+  - ext; Copyright (c) 2011-2022, Mariusz Nowak, @medikoo, medikoo.com
+  - memoizee; Copyright (c) 2012-2018, Mariusz Nowak, @medikoo, medikoo.com
+  - next-tick; Copyright (c) 2012-2020, Mariusz Nowak, @medikoo, medikoo.com
+  - timers-ext; Copyright (c) 2013-2018, Mariusz Nowak, @medikoo, medikoo.com
+  - type; Copyright (c) 2019, Mariusz Nowak, @medikoo, medikoo.com
+-----------------------------------------------------------------------------
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+================================================================================
+
+License text 93
 Packages: axe-core 4.12.1
 
 Mozilla Public License, version 2.0
@@ -7589,79 +7715,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 ================================================================================
 
-License text 91
-Packages: axe-core 4.12.1
-
------------------------------------------------------------------------------
-                              MIT License
-  Applies to: 
-  - colorjs.io; Copyright (c) 2021 Lea Verou, Chris Lilley
-  - core-js-pure; Copyright (c) 2014-2023 Denis Pushkarev
-  - css-selector-parser; Copyright (c) 2013 Dulin Marat
-  - doT.js; Copyright (c) 2011 Laura Doktorova
-      Software includes portions from jQote2 Copyright (c) 2010 aefxx,
-      http://aefxx.com/ licensed under the MIT license.
-  - emoji-regex; Copyright (c) Mathias Bynens <https://mathiasbynens.be/>
-  - es6-iterator; Copyright (c) 2013-2017 Mariusz Nowak (www.medikoo.com)
-  - es6-promise;
-      Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
-  - event-emitter; Copyright (C) 2012-2015 Mariusz Nowak (www.medikoo.com)
-  - is-promise; Copyright (c) 2014 Forbes Lindesay
-  - lru-queue; Copyright (C) 2014 Mariusz Nowak (www.medikoo.com)
-  - typedarray;
-      Copyright (c) 2010, Linden Research, Inc.
-      Copyright (c) 2012, Joshua Bell
-  - weakmap-polyfill; Copyright (c) 2015-2021 polygonplanet
------------------------------------------------------------------------------
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
------------------------------------------------------------------------------
-                              ISC License
-  Applies to: 
-  - d; Copyright (c) 2013-2019, Mariusz Nowak, @medikoo, medikoo.com
-  - es5-ext; Copyright (c) 2011-2022, Mariusz Nowak, @medikoo, medikoo.com
-  - es6-symbol; Copyright (c) 2013-2019, Mariusz Nowak, @medikoo, medikoo.com
-  - es6-weak-map; Copyright (c) 2013-2018, Mariusz Nowak, @medikoo, medikoo.com
-  - ext; Copyright (c) 2011-2022, Mariusz Nowak, @medikoo, medikoo.com
-  - memoizee; Copyright (c) 2012-2018, Mariusz Nowak, @medikoo, medikoo.com
-  - next-tick; Copyright (c) 2012-2020, Mariusz Nowak, @medikoo, medikoo.com
-  - timers-ext; Copyright (c) 2013-2018, Mariusz Nowak, @medikoo, medikoo.com
-  - type; Copyright (c) 2019, Mariusz Nowak, @medikoo, medikoo.com
------------------------------------------------------------------------------
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
-OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
-
-================================================================================
-
-License text 92
+License text 94
 Packages: axios 1.18.1
 
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
@@ -7674,7 +7728,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 93
+License text 95
 Packages: balanced-match 4.0.4
 
 (MIT)
@@ -7703,7 +7757,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 94
+License text 96
 Packages: base64-js 1.5.1
 
 The MIT License (MIT)
@@ -7730,7 +7784,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 95
+License text 97
 Packages: bidi-js 1.0.3
 
 Copyright (c) 2021 Jason Johnston
@@ -7758,7 +7812,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 96
+License text 98
 Packages: binary-extensions 2.3.0
 
 MIT License
@@ -7774,7 +7828,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 97
+License text 99
 Packages: bluebird 3.7.2
 
 The MIT License (MIT)
@@ -7801,7 +7855,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 98
+License text 100
 Packages: brace-expansion 5.0.8
 
 MIT License
@@ -7830,7 +7884,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 99
+License text 101
 Packages: braces 3.0.3; fill-range 7.1.1; is-number 7.0.0; micromatch 4.0.8
 
 The MIT License (MIT)
@@ -7857,7 +7911,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 100
+License text 102
 Packages: browserslist 4.28.2
 
 The MIT License (MIT)
@@ -7883,7 +7937,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 101
+License text 103
 Packages: buffer-from 1.1.2
 
 MIT License
@@ -7910,7 +7964,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 102
+License text 104
 Packages: builder-util 26.15.3; builder-util-runtime 9.7.0; electron-builder 26.15.3; electron-builder-squirrel-windows 26.15.3; electron-publish 26.15.3; electron-updater 6.8.9
 
 The MIT License (MIT)
@@ -7937,7 +7991,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 103
+License text 105
 Packages: bytestreamjs 2.0.1
 
 Copyright (c) 2016-2022, Peculiar Ventures
@@ -7972,7 +8026,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 104
+License text 106
 Packages: cacheable-lookup 5.0.4
 
 MIT License
@@ -7999,7 +8053,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 105
+License text 107
 Packages: cacheable-request 7.0.4; clone-response 1.0.3
 
 MIT License
@@ -8026,7 +8080,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 106
+License text 108
 Packages: call-bind 1.0.9; get-intrinsic 1.3.0
 
 MIT License
@@ -8053,7 +8107,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 107
+License text 109
 Packages: call-bind-apply-helpers 1.0.2; call-bound 1.0.4; data-view-byte-length 1.0.2; data-view-byte-offset 1.0.1; es-define-property 1.0.1; es-errors 1.3.0; es-object-atoms 1.1.1, 1.1.2; own-keys 1.0.1; possible-typed-array-names 1.1.0; safe-push-apply 1.0.0; set-proto 1.0.0; side-channel-list 1.0.1; side-channel-map 1.0.1
 
 MIT License
@@ -8080,7 +8134,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 108
+License text 110
 Packages: camelcase-css 2.0.1
 
 The MIT License (MIT)
@@ -8107,7 +8161,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 109
+License text 111
 Packages: caniuse-lite 1.0.30001791
 
 Attribution 4.0 International
@@ -8161,7 +8215,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public: 
+     for the public:
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
@@ -8508,7 +8562,7 @@ Creative Commons may be contacted at creativecommons.org.
 
 ================================================================================
 
-License text 110
+License text 112
 Packages: chai 6.2.2
 
 MIT License
@@ -8535,7 +8589,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 111
+License text 113
 Packages: chokidar 3.6.0, 4.0.3
 
 The MIT License (MIT)
@@ -8562,8 +8616,35 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 112
-Packages: chownr 3.0.0
+License text 114
+Packages: chokidar 3.6.0, 4.0.3
+
+The MIT License (MIT)
+
+Copyright (c) 2012-2019 Paul Miller (https://paulmillr.com), Elan Shanker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+================================================================================
+
+License text 115
+Packages: chownr 3.0.0; yallist 5.0.0
 
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -8631,7 +8712,7 @@ software or this license, under any kind of legal claim.***
 
 ================================================================================
 
-License text 113
+License text 116
 Packages: ci-info 4.3.1, 4.4.0
 
 The MIT License (MIT)
@@ -8658,7 +8739,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 114
+License text 117
 Packages: class-variance-authority 0.7.1
 
 Apache License
@@ -8854,7 +8935,7 @@ Apache License
 
 ================================================================================
 
-License text 115
+License text 118
 Packages: cliui 8.0.1
 
 Copyright (c) 2015, Contributors
@@ -8874,7 +8955,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 116
+License text 119
 Packages: clsx 2.1.1; escalade 3.2.0
 
 MIT License
@@ -8889,7 +8970,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 117
+License text 120
 Packages: cmdk 1.1.1
 
 MIT License
@@ -8916,7 +8997,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 118
+License text 121
 Packages: color-convert 2.0.1
 
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
@@ -8942,7 +9023,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 119
+License text 122
 Packages: color-name 1.1.4
 
 The MIT License (MIT)
@@ -8956,7 +9037,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 120
+License text 123
 Packages: combined-stream 1.0.8; delayed-stream 1.0.0
 
 Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
@@ -8981,7 +9062,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 121
+License text 124
 Packages: commander 4.1.1, 5.1.0, 7.2.0, 8.3.0
 
 (The MIT License)
@@ -9009,10 +9090,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 122
+License text 125
 Packages: convert-source-map 2.0.0
 
-Copyright 2013 Thorsten Lorenz. 
+Copyright 2013 Thorsten Lorenz.
 All rights reserved.
 
 Permission is hereby granted, free of charge, to any person
@@ -9038,7 +9119,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 123
+License text 126
 Packages: core-util-is 1.0.3
 
 Copyright Node.js contributors. All rights reserved.
@@ -9063,7 +9144,7 @@ IN THE SOFTWARE.
 
 ================================================================================
 
-License text 124
+License text 127
 Packages: cose-base 1.0.3, 2.2.0
 
 MIT License
@@ -9090,7 +9171,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 125
+License text 128
 Packages: crelt 1.0.6
 
 Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>
@@ -9115,7 +9196,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 126
+License text 129
 Packages: cross-spawn 7.0.6; proper-lockfile 4.1.2
 
 The MIT License (MIT)
@@ -9142,7 +9223,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 127
+License text 130
 Packages: css-tree 3.2.1
 
 Copyright (C) 2016-2026 by Roman Dvornov
@@ -9167,7 +9248,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 128
+License text 131
 Packages: cssesc 3.0.0; emoji-regex 8.0.0, 9.2.2; is-potential-custom-element-name 1.0.1; punycode 2.3.1; string.prototype.includes 2.0.1
 
 Copyright Mathias Bynens <https://mathiasbynens.be/>
@@ -9193,7 +9274,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 129
+License text 132
 Packages: csstype 3.2.3
 
 Copyright (c) 2017-2018 Fredrik Nicol
@@ -9218,7 +9299,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 130
+License text 133
 Packages: cytoscape 3.34.0
 
 Copyright (c) 2016-2026, The Cytoscape Consortium.
@@ -9243,7 +9324,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 131
+License text 134
 Packages: cytoscape 3.34.0
 
 import fs from 'fs';
@@ -9281,7 +9362,7 @@ fs.writeFileSync(path.join(__dirname, 'LICENSE'), license);
 
 ================================================================================
 
-License text 132
+License text 135
 Packages: cytoscape-cose-bilkent 4.1.0
 
 Copyright (c) 2016-2018, The Cytoscape Consortium.
@@ -9306,7 +9387,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 133
+License text 136
 Packages: cytoscape-fcose 2.2.0
 
 Copyright (c) 2018 - present, iVis-at-Bilkent.
@@ -9331,8 +9412,8 @@ SOFTWARE.
 
 ================================================================================
 
-License text 134
-Packages: d3 7.9.0; d3-array 2.12.1; d3-array 3.2.4
+License text 137
+Packages: d3 7.9.0; d3-array 3.2.4
 
 Copyright 2010-2023 Mike Bostock
 
@@ -9350,7 +9431,40 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 135
+License text 138
+Packages: d3-array 2.12.1
+
+Copyright 2010-2020 Mike Bostock
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
+License text 139
 Packages: d3-axis 3.0.0; d3-brush 3.0.0; d3-chord 3.0.1; d3-dispatch 3.0.1; d3-drag 3.0.0; d3-force 3.0.0; d3-hierarchy 3.1.2; d3-interpolate 3.0.1; d3-polygon 3.0.1; d3-quadtree 3.0.1; d3-random 3.0.1; d3-scale 4.0.2; d3-selection 3.0.0; d3-time-format 4.1.0; d3-timer 3.0.1; d3-transition 3.0.1; d3-zoom 3.0.0
 
 Copyright 2010-2021 Mike Bostock
@@ -9369,8 +9483,8 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 136
-Packages: d3-color 3.1.0; d3-shape 1.3.7; d3-shape 3.2.0; d3-time 3.1.0
+License text 140
+Packages: d3-color 3.1.0; d3-shape 3.2.0; d3-time 3.1.0
 
 Copyright 2010-2022 Mike Bostock
 
@@ -9388,7 +9502,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 137
+License text 141
 Packages: d3-contour 4.0.2
 
 Copyright 2012-2023 Mike Bostock
@@ -9407,7 +9521,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 138
+License text 142
 Packages: d3-delaunay 6.0.4
 
 Copyright 2018-2021 Observable, Inc.
@@ -9427,7 +9541,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 139
+License text 143
 Packages: d3-dsv 3.0.1
 
 Copyright 2013-2021 Mike Bostock
@@ -9446,7 +9560,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 140
+License text 144
 Packages: d3-ease 3.0.1
 
 Copyright 2010-2021 Mike Bostock
@@ -9480,7 +9594,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 141
+License text 145
 Packages: d3-fetch 3.0.1
 
 Copyright 2016-2021 Mike Bostock
@@ -9499,7 +9613,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 142
+License text 146
 Packages: d3-format 3.1.2
 
 Copyright 2010-2026 Mike Bostock
@@ -9518,7 +9632,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 143
+License text 147
 Packages: d3-geo 3.1.1
 
 Copyright 2010-2024 Mike Bostock
@@ -9558,8 +9672,41 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 144
-Packages: d3-path 1.0.9; d3-path 3.1.0
+License text 148
+Packages: d3-path 1.0.9
+
+Copyright 2015-2016 Mike Bostock
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
+License text 149
+Packages: d3-path 3.1.0
 
 Copyright 2015-2022 Mike Bostock
 
@@ -9577,7 +9724,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 145
+License text 150
 Packages: d3-sankey 0.12.3
 
 Copyright 2015, Mike Bostock
@@ -9610,7 +9757,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 146
+License text 151
 Packages: d3-scale-chromatic 3.1.0
 
 Copyright 2010-2024 Mike Bostock
@@ -9644,7 +9791,40 @@ specific language governing permissions and limitations under the License.
 
 ================================================================================
 
-License text 147
+License text 152
+Packages: d3-shape 1.3.7
+
+Copyright 2010-2015 Mike Bostock
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
+License text 153
 Packages: dagre-d3-es 7.0.14
 
 Original dagre-d3 copyright: Copyright (c) 2013 Chris Pettitt
@@ -9673,7 +9853,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 148
+License text 154
 Packages: damerau-levenshtein 1.0.8
 
 BSD 2-Clause License
@@ -9704,7 +9884,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 149
+License text 155
 Packages: data-urls 7.0.0; html-encoding-sniffer 6.0.0; whatwg-mimetype 5.0.0
 
 Copyright © Domenic Denicola <d@domenic.me>
@@ -9717,7 +9897,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 150
+License text 156
 Packages: data-view-buffer 1.0.2; define-data-property 1.1.4; safe-array-concat 1.1.4; stop-iteration-iterator 1.1.0; typed-array-buffer 1.0.3
 
 MIT License
@@ -9744,7 +9924,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 151
+License text 157
 Packages: dayjs 1.11.20
 
 MIT License
@@ -9771,7 +9951,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 152
+License text 158
 Packages: debug 4.4.3
 
 (The MIT License)
@@ -9796,7 +9976,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 153
+License text 159
 Packages: decimal.js 10.6.0
 
 The MIT Licence.
@@ -9824,7 +10004,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 154
+License text 160
 Packages: deep-is 0.1.4
 
 Copyright (c) 2012, 2013 Thorsten Lorenz <thlorenz@gmx.de>
@@ -9852,7 +10032,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 155
+License text 161
 Packages: delaunator 5.1.0
 
 ISC License
@@ -9873,7 +10053,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 156
+License text 162
 Packages: detect-libc 2.1.2; ts-interface-checker 0.1.13
 
 Apache License
@@ -10080,7 +10260,7 @@ Apache License
 
 ================================================================================
 
-License text 157
+License text 163
 Packages: detect-node-es 1.1.0
 
 MIT License
@@ -10107,7 +10287,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 158
+License text 164
 Packages: didyoumean 1.2.2
 
 ## License
@@ -10127,13 +10307,13 @@ limitations under the License.
 
 ================================================================================
 
-License text 159
+License text 165
 Packages: dir-compare 4.2.0
 
 Copyright 2014 Liviu Grigorescu (grigoresculiviu@gmail.com)
 
 This project is free software released under the MIT license:
-http://www.opensource.org/licenses/mit-license.php 
+http://www.opensource.org/licenses/mit-license.php
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10155,7 +10335,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 160
+License text 166
 Packages: dnd-core 16.0.1; react-dnd-html5-backend 16.0.1
 
 The MIT License (MIT)
@@ -10182,7 +10362,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 161
+License text 167
 Packages: doctrine 3.0.0
 
 Apache License
@@ -10364,7 +10544,7 @@ END OF TERMS AND CONDITIONS
 
 ================================================================================
 
-License text 162
+License text 168
 Packages: doctrine 3.0.0; estraverse 5.3.0; esutils 2.0.3
 
 Redistribution and use in source and binary forms, with or without
@@ -10389,7 +10569,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 163
+License text 169
 Packages: docx 9.7.1
 
 The MIT License (MIT)
@@ -10416,7 +10596,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 164
+License text 170
 Packages: dompurify 3.4.12
 
 Mozilla Public License Version 2.0
@@ -10456,7 +10636,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -10795,7 +10975,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 ================================================================================
 
-License text 165
+License text 171
 Packages: dotenv 16.6.1
 
 Copyright (c) 2015, Scott Motte
@@ -10824,7 +11004,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 166
+License text 172
 Packages: dotenv-expand 11.0.7
 
 Copyright (c) 2016, Scott Motte
@@ -10853,7 +11033,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 167
+License text 173
 Packages: dunder-proto 1.0.1; math-intrinsics 1.1.0
 
 MIT License
@@ -10880,25 +11060,25 @@ SOFTWARE.
 
 ================================================================================
 
-License text 168
+License text 174
 Packages: duplexer2 0.1.4
 
 Copyright (c) 2013, Deoxxa Development
 ======================================
 All rights reserved.
 --------------------
-  
+
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:  
+modification, are permitted provided that the following conditions are met:
 1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.  
+   notice, this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright
    notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.  
+   documentation and/or other materials provided with the distribution.
 3. Neither the name of Deoxxa Development nor the names of its contributors
    may be used to endorse or promote products derived from this software
-   without specific prior written permission.  
-  
+   without specific prior written permission.
+
 THIS SOFTWARE IS PROVIDED BY DEOXXA DEVELOPMENT ''AS IS'' AND ANY
 EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -10912,7 +11092,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 169
+License text 175
 Packages: electron 43.1.1
 
 Copyright (c) Electron contributors
@@ -10939,7 +11119,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 170
+License text 176
 Packages: electron-log 5.4.4
 
 The MIT License (MIT)
@@ -10966,7 +11146,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 171
+License text 177
 Packages: electron-to-chromium 1.5.350
 
 Copyright 2018 Kilian Valkhof
@@ -10977,7 +11157,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ================================================================================
 
-License text 172
+License text 178
 Packages: electron-winstaller 5.4.0
 
 Copyright (c) 2015 GitHub Inc.
@@ -11003,7 +11183,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 173
+License text 179
 Packages: end-of-stream 1.4.5; pump 3.0.4
 
 The MIT License (MIT)
@@ -11030,7 +11210,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 174
+License text 180
 Packages: entities 8.0.0
 
 Copyright (c) Felix Böhm
@@ -11047,7 +11227,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 175
+License text 181
 Packages: es-module-lexer 2.3.1
 
 MIT License
@@ -11063,7 +11243,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 176
+License text 182
 Packages: es-set-tostringtag 2.1.0
 
 MIT License
@@ -11090,7 +11270,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 177
+License text 183
 Packages: es-shim-unscopables 1.1.0; gopd 1.2.0; safe-regex-test 1.1.0
 
 MIT License
@@ -11117,7 +11297,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 178
+License text 184
 Packages: es-to-primitive 1.3.0; is-boolean-object 1.2.2; is-callable 1.2.7; is-date-object 1.1.0; is-number-object 1.1.1; is-string 1.1.1; is-symbol 1.1.1; is-typed-array 1.1.15; object.values 1.2.1; string.prototype.trim 1.2.11; which-typed-array 1.1.22
 
 The MIT License (MIT)
@@ -11144,7 +11324,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 179
+License text 185
 Packages: es-toolkit 1.47.0
 
 MIT License
@@ -11175,7 +11355,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 180
+License text 186
 Packages: eslint-plugin-jsx-a11y 6.10.2; jsx-ast-utils 3.3.5
 
 The MIT License (MIT)
@@ -11189,7 +11369,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 181
+License text 187
 Packages: eslint-plugin-react-hooks 4.6.2; react-is 16.13.1
 
 MIT License
@@ -11216,7 +11396,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 182
+License text 188
 Packages: eslint-plugin-sonarjs 1.0.4
 
 GNU LESSER GENERAL PUBLIC LICENSE
@@ -11387,7 +11567,7 @@ Library.
 
 ================================================================================
 
-License text 183
+License text 189
 Packages: eslint-scope 7.2.2
 
 Copyright JS Foundation and other contributors, https://js.foundation
@@ -11415,7 +11595,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 184
+License text 190
 Packages: eslint-visitor-keys 3.4.3, 5.0.1
 
 Apache License
@@ -11622,7 +11802,7 @@ Apache License
 
 ================================================================================
 
-License text 185
+License text 191
 Packages: espree 9.6.1
 
 BSD 2-Clause License
@@ -11653,7 +11833,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 186
+License text 192
 Packages: esquery 1.7.0
 
 Copyright (c) 2013, Joel Feenstra
@@ -11683,7 +11863,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 187
+License text 193
 Packages: estree-walker 3.0.3
 
 Copyright (c) 2015-20 [these people](https://github.com/Rich-Harris/estree-walker/graphs/contributors)
@@ -11696,7 +11876,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 188
+License text 194
 Packages: expect-type 1.4.0
 
 Copyright 2024 Misha Kaletsky
@@ -11893,7 +12073,7 @@ Copyright 2024 Misha Kaletsky
 
 ================================================================================
 
-License text 189
+License text 195
 Packages: exponential-backoff 3.1.3
 
 Apache License
@@ -12100,7 +12280,7 @@ Apache License
 
 ================================================================================
 
-License text 190
+License text 196
 Packages: fake-indexeddb 6.2.5
 
 Apache License
@@ -12314,7 +12494,7 @@ APPENDIX: How to apply the Apache License to your work
 
 ================================================================================
 
-License text 191
+License text 197
 Packages: fast-deep-equal 3.1.3; json-schema-traverse 0.4.1, 1.0.0
 
 MIT License
@@ -12341,7 +12521,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 192
+License text 198
 Packages: fast-json-stable-stringify 2.1.0
 
 This software is released under the MIT license:
@@ -12368,7 +12548,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 193
+License text 199
 Packages: fast-levenshtein 2.0.6
 
 (MIT License)
@@ -12398,7 +12578,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 194
+License text 200
 Packages: fast-uri 3.1.4
 
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
@@ -12434,7 +12614,7 @@ The complete list of contributors can be found at:
 
 ================================================================================
 
-License text 195
+License text 201
 Packages: fastq 1.20.1
 
 Copyright (c) 2015-2020, Matteo Collina <matteo.collina@gmail.com>
@@ -12453,7 +12633,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 196
+License text 202
 Packages: fdir 6.5.0
 
 Copyright 2023 Abdullah Atta
@@ -12466,7 +12646,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 197
+License text 203
 Packages: file-entry-cache 6.0.1
 
 The MIT License (MIT)
@@ -12493,7 +12673,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 198
+License text 204
 Packages: flat-cache 3.2.0
 
 The MIT License (MIT)
@@ -12520,7 +12700,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 199
+License text 205
 Packages: flatted 3.4.2
 
 ISC License
@@ -12541,7 +12721,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 200
+License text 206
 Packages: follow-redirects 1.16.0
 
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
@@ -12565,7 +12745,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 201
+License text 207
 Packages: for-each 0.3.5
 
 The MIT License (MIT)
@@ -12592,7 +12772,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 202
+License text 208
 Packages: form-data 4.0.6
 
 Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
@@ -12617,7 +12797,7 @@ Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 
 ================================================================================
 
-License text 203
+License text 209
 Packages: fraction.js 5.3.4
 
 MIT License
@@ -12644,7 +12824,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 204
+License text 210
 Packages: fs-extra 7.0.1, 8.1.0, 9.1.0, 10.1.0, 11.3.1, 11.3.6
 
 (The MIT License)
@@ -12665,7 +12845,28 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 
 ================================================================================
 
-License text 205
+License text 211
+Packages: fs-extra 7.0.1, 8.1.0, 9.1.0, 10.1.0, 11.3.1, 11.3.6
+
+(The MIT License)
+
+Copyright (c) 2011-2024 JP Richardson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+(the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
+ merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+License text 212
 Packages: fs.realpath 1.0.0
 
 The ISC License
@@ -12714,7 +12915,7 @@ the licensed code:
 
 ================================================================================
 
-License text 206
+License text 213
 Packages: function-bind 1.1.2
 
 Copyright (c) 2013 Raynos.
@@ -12739,7 +12940,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 207
+License text 214
 Packages: function.prototype.name 1.2.0; globalthis 1.0.4
 
 The MIT License (MIT)
@@ -12766,7 +12967,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 208
+License text 215
 Packages: functions-have-names 1.2.3; has-bigints 1.1.0; internal-slot 1.1.0; side-channel 1.1.1; side-channel-weakmap 1.0.2; unbox-primitive 1.1.0; which-boxed-primitive 1.1.1
 
 MIT License
@@ -12793,7 +12994,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 209
+License text 216
 Packages: generator-function 2.0.1
 
 Copyright (c) 2015 Tiancheng “Timothy” Gu
@@ -12806,7 +13007,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 210
+License text 217
 Packages: get-caller-file 2.0.5
 
 ISC License (ISC)
@@ -12818,7 +13019,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ================================================================================
 
-License text 211
+License text 218
 Packages: get-nonce 1.0.1
 
 MIT License
@@ -12845,7 +13046,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 212
+License text 219
 Packages: get-proto 1.0.1
 
 MIT License
@@ -12872,7 +13073,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 213
+License text 220
 Packages: get-symbol-description 1.1.0; has-tostringtag 1.0.2; is-shared-array-buffer 1.0.4
 
 MIT License
@@ -12899,7 +13100,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 214
+License text 221
 Packages: glob 7.2.3
 
 The ISC License
@@ -12926,7 +13127,28 @@ https://creativecommons.org/licenses/by-sa/4.0/
 
 ================================================================================
 
-License text 215
+License text 222
+Packages: glob-parent 5.1.2, 6.0.2
+
+The ISC License
+
+Copyright (c) 2015, 2019 Elan Shanker
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+================================================================================
+
+License text 223
 Packages: glob-parent 5.1.2, 6.0.2
 
 The ISC License
@@ -12947,7 +13169,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 216
+License text 224
 Packages: graceful-fs 4.2.11
 
 The ISC License
@@ -12968,7 +13190,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 217
+License text 225
 Packages: graphemer 1.4.0
 
 Copyright 2020 Filament (Anomalous Technologies Limited)
@@ -12992,7 +13214,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 218
+License text 226
 Packages: hachure-fill 0.5.2
 
 MIT License
@@ -13019,7 +13241,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 219
+License text 227
 Packages: hammerjs 2.0.8
 
 The MIT License (MIT)
@@ -13046,7 +13268,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 220
+License text 228
 Packages: has-property-descriptors 1.0.2; has-proto 1.2.0; supports-preserve-symlinks-flag 1.0.0
 
 MIT License
@@ -13073,7 +13295,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 221
+License text 229
 Packages: has-symbols 1.1.0
 
 MIT License
@@ -13100,7 +13322,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 222
+License text 230
 Packages: hasown 2.0.3, 2.0.4; set-function-length 1.2.2; set-function-name 2.0.2
 
 MIT License
@@ -13127,7 +13349,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 223
+License text 231
 Packages: hoist-non-react-statics 3.3.2
 
 Software License Agreement (BSD License)
@@ -13162,7 +13384,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 224
+License text 232
 Packages: hosted-git-info 4.1.0
 
 Copyright (c) 2015, Rebecca Turner
@@ -13181,7 +13403,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 225
+License text 233
 Packages: http-cache-semantics 4.2.0
 
 Copyright 2016-2018 Kornel Lesiński
@@ -13196,7 +13418,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 ================================================================================
 
-License text 226
+License text 234
 Packages: i18next 26.3.1
 
 The MIT License (MIT)
@@ -13223,7 +13445,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 227
+License text 235
 Packages: iconv-lite 0.6.3
 
 Copyright (c) 2011 Alexander Shtuchkin
@@ -13249,7 +13471,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 228
+License text 236
 Packages: idb 8.0.3
 
 ISC License (ISC)
@@ -13261,7 +13483,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ================================================================================
 
-License text 229
+License text 237
 Packages: ignore 5.3.2, 7.0.5
 
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
@@ -13288,7 +13510,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 230
+License text 238
 Packages: immediate 3.0.6
 
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, Domenic Denicola, Brian Cavalier
@@ -13314,7 +13536,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 231
+License text 239
 Packages: immutable 5.1.8
 
 MIT License
@@ -13341,7 +13563,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 232
+License text 240
 Packages: import-meta-resolve 4.2.0
 
 (The MIT License)
@@ -13421,7 +13643,7 @@ IN THE SOFTWARE.
 
 ================================================================================
 
-License text 233
+License text 241
 Packages: inflight 1.0.6
 
 The ISC License
@@ -13442,7 +13664,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 234
+License text 242
 Packages: inherits 2.0.4
 
 The ISC License
@@ -13463,7 +13685,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 235
+License text 243
 Packages: internmap 1.0.1, 2.0.3
 
 Copyright 2021 Mike Bostock
@@ -13482,7 +13704,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 236
+License text 244
 Packages: is-array-buffer 3.0.5
 
 MIT License
@@ -13509,7 +13731,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 237
+License text 245
 Packages: is-async-function 2.1.1
 
 The MIT License (MIT)
@@ -13535,7 +13757,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 238
+License text 246
 Packages: is-bigint 1.1.0; object.fromentries 2.0.8
 
 MIT License
@@ -13562,7 +13784,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 239
+License text 247
 Packages: is-binary-path 2.1.0
 
 MIT License
@@ -13577,7 +13799,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 240
+License text 248
 Packages: is-core-module 2.16.2
 
 The MIT License (MIT)
@@ -13603,7 +13825,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 241
+License text 249
 Packages: is-data-view 1.0.2
 
 MIT License
@@ -13630,7 +13852,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 242
+License text 250
 Packages: is-document.all 1.0.0
 
 MIT License
@@ -13657,7 +13879,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 243
+License text 251
 Packages: is-extglob 2.1.1; word-wrap 1.2.5
 
 The MIT License (MIT)
@@ -13684,7 +13906,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 244
+License text 252
 Packages: is-generator-function 1.1.2; is-negative-zero 2.0.3; is-regex 1.2.1
 
 The MIT License (MIT)
@@ -13710,7 +13932,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 245
+License text 253
 Packages: is-glob 4.0.3
 
 The MIT License (MIT)
@@ -13737,7 +13959,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 246
+License text 254
 Packages: is-map 2.0.3; is-set 2.0.3; is-weakmap 2.0.2; is-weakset 2.0.4; which-collection 1.0.2
 
 MIT License
@@ -13764,7 +13986,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 247
+License text 255
 Packages: isarray 1.0.0, 2.0.5
 
 MIT License
@@ -13791,7 +14013,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 248
+License text 256
 Packages: isbinaryfile 4.0.10, 5.0.7
 
 Copyright (c) 2019 Garen J. Torikian
@@ -13819,7 +14041,68 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 249
+License text 257
+Packages: isexe 3.1.5, 4.0.0; lru-cache 11.5.2; minipass 7.1.3; sax 1.6.0; tar 7.5.20
+
+# Blue Oak Model License
+
+Version 1.0.0
+
+## Purpose
+
+This license gives everyone as much permission to work with
+this software as possible, while protecting contributors
+from liability.
+
+## Acceptance
+
+In order to receive this license, you must agree to its
+rules.  The rules of this license are both obligations
+under that agreement and conditions to your license.
+You must not do anything with this software that triggers
+a rule that you cannot or will not follow.
+
+## Copyright
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe that contributor's
+copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of
+any part of this software from you, with or without
+changes, also gets the text of this license or a link to
+<https://blueoakcouncil.org/license/1.0.0>.
+
+## Excuse
+
+If anyone notifies you in writing that you have not
+complied with [Notices](#notices), you can keep your
+license by taking all practical steps to comply within 30
+days after the notice.  If you do not do so, your license
+ends immediately.
+
+## Patent
+
+Each contributor licenses you to do everything with this
+software that would otherwise infringe any patent claims
+they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license.
+
+## No Liability
+
+***As far as the law allows, this software comes as is,
+without any warranty or condition, and no contributor
+will be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.***
+
+================================================================================
+
+License text 258
 Packages: jiti 1.21.7, 2.7.0; std-env 4.2.0
 
 MIT License
@@ -13846,7 +14129,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 250
+License text 259
 Packages: jotai 2.15.2
 
 MIT License
@@ -13873,7 +14156,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 251
+License text 260
 Packages: js-tokens 4.0.0
 
 The MIT License (MIT)
@@ -13900,7 +14183,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 252
+License text 261
 Packages: js-yaml 4.3.0
 
 (The MIT License)
@@ -13927,7 +14210,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 253
+License text 262
 Packages: jsdom 29.1.1
 
 Copyright (c) 2010 Elijah Insua
@@ -13955,35 +14238,35 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 254
+License text 263
 Packages: json-buffer 3.0.1
 
 Copyright (c) 2013 Dominic Tarr
 
-Permission is hereby granted, free of charge, 
-to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to 
-deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, 
-merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, 
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice 
+The above copyright notice and this permission notice
 shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 255
+License text 264
 Packages: json-stable-stringify-without-jsonify 1.0.1; minimist 1.2.8; text-table 0.2.0
 
 This software is released under the MIT license:
@@ -14007,7 +14290,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 256
+License text 265
 Packages: json5 2.2.3
 
 MIT License
@@ -14036,7 +14319,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 257
+License text 266
 Packages: jsonfile 4.0.0, 6.2.1
 
 (The MIT License)
@@ -14057,7 +14340,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 
 ================================================================================
 
-License text 258
+License text 267
 Packages: jszip 3.10.1
 
 JSZip is dual licensed. At your choice you may use it under the MIT license *or* the GPLv3
@@ -14714,7 +14997,7 @@ copy of the Program in return for a fee.
 
 ================================================================================
 
-License text 259
+License text 268
 Packages: katex 0.16.45, 0.17.0
 
 The MIT License (MIT)
@@ -14741,7 +15024,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 260
+License text 269
 Packages: khroma 2.1.0
 
 The MIT License (MIT)
@@ -14768,7 +15051,7 @@ DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 261
+License text 270
 Packages: layout-base 1.0.2, 2.0.1
 
 MIT License
@@ -14795,7 +15078,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 262
+License text 271
 Packages: levn 0.4.1; optionator 0.9.4; prelude-ls 1.2.1; type-check 0.4.0
 
 Copyright (c) George Zahariev
@@ -14823,7 +15106,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 263
+License text 272
 Packages: lie 3.3.0
 
 #Copyright (c) 2014-2018 Calvin Metcalf, Jordan Harband
@@ -14836,7 +15119,7 @@ The above copyright notice and this permission notice shall be included in all c
 
 ================================================================================
 
-License text 264
+License text 273
 Packages: lightningcss 1.32.0
 
 Mozilla Public License Version 2.0
@@ -15215,7 +15498,7 @@ defined by the Mozilla Public License, v. 2.0.
 
 ================================================================================
 
-License text 265
+License text 274
 Packages: lilconfig 3.1.3
 
 MIT License
@@ -15242,7 +15525,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 266
+License text 275
 Packages: lines-and-columns 1.2.4
 
 The MIT License (MIT)
@@ -15269,7 +15552,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 267
+License text 276
 Packages: lodash 4.18.1; lodash-es 4.18.1; lodash.merge 4.6.2
 
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
@@ -15322,7 +15605,7 @@ terms above.
 
 ================================================================================
 
-License text 268
+License text 277
 Packages: lodash.escaperegexp 4.1.2
 
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
@@ -15375,7 +15658,7 @@ terms above.
 
 ================================================================================
 
-License text 269
+License text 278
 Packages: lodash.isequal 4.5.0
 
 Copyright JS Foundation and other contributors <https://js.foundation/>
@@ -15428,7 +15711,7 @@ terms above.
 
 ================================================================================
 
-License text 270
+License text 279
 Packages: loose-envify 1.4.0
 
 The MIT License (MIT)
@@ -15455,8 +15738,8 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 271
-Packages: lru-cache 11.5.2; lru-cache 6.0.0, 10.2.0
+License text 280
+Packages: lru-cache 6.0.0, 10.2.0
 
 The ISC License
 
@@ -15476,7 +15759,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 272
+License text 281
 Packages: lucide-react 1.14.0
 
 ISC License
@@ -15525,7 +15808,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 273
+License text 282
 Packages: magic-string 0.30.21
 
 Copyright 2018 Rich Harris
@@ -15538,7 +15821,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 274
+License text 283
 Packages: marked 12.0.2, 16.4.2
 
 # License information
@@ -15588,7 +15871,7 @@ This software is provided by the copyright holders and contributors “as is” 
 
 ================================================================================
 
-License text 275
+License text 284
 Packages: mdn-data 2.27.1
 
 CC0 1.0 Universal
@@ -15710,7 +15993,7 @@ For more information, please see
 
 ================================================================================
 
-License text 276
+License text 285
 Packages: merge2 1.4.1
 
 The MIT License (MIT)
@@ -15737,7 +16020,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 277
+License text 286
 Packages: mermaid 11.15.0
 
 The MIT License (MIT)
@@ -15764,7 +16047,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 278
+License text 287
 Packages: mime 2.6.0
 
 The MIT License (MIT)
@@ -15791,7 +16074,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 279
+License text 288
 Packages: mime-db 1.52.0
 
 (The MIT License)
@@ -15820,7 +16103,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 280
+License text 289
 Packages: mime-types 2.1.35
 
 (The MIT License)
@@ -15849,7 +16132,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 281
+License text 290
 Packages: minimalistic-assert 1.0.1
 
 Copyright 2015 Calvin Metcalf
@@ -15868,8 +16151,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 282
-Packages: minipass 7.1.3; sax 1.6.0; tar 7.5.20
+License text 291
+Packages: minimatch 10.2.5
 
 # Blue Oak Model License
 
@@ -15884,7 +16167,7 @@ from liability.
 ## Acceptance
 
 In order to receive this license, you must agree to its
-rules.  The rules of this license are both obligations
+rules. The rules of this license are both obligations
 under that agreement and conditions to your license.
 You must not do anything with this software that triggers
 a rule that you cannot or will not follow.
@@ -15907,7 +16190,7 @@ changes, also gets the text of this license or a link to
 If anyone notifies you in writing that you have not
 complied with [Notices](#notices), you can keep your
 license by taking all practical steps to comply within 30
-days after the notice.  If you do not do so, your license
+days after the notice. If you do not do so, your license
 ends immediately.
 
 ## Patent
@@ -15922,14 +16205,35 @@ No contributor can revoke this license.
 
 ## No Liability
 
-***As far as the law allows, this software comes as is,
+**_As far as the law allows, this software comes as is,
 without any warranty or condition, and no contributor
 will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.***
+software or this license, under any kind of legal claim._**
 
 ================================================================================
 
-License text 283
+License text 292
+Packages: minimatch 3.1.5, 5.1.9, 9.0.9
+
+The ISC License
+
+Copyright (c) 2011-2023 Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+================================================================================
+
+License text 293
 Packages: minizlib 3.1.0
 
 Minizlib was created by Isaac Z. Schlueter.
@@ -15961,7 +16265,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 284
+License text 294
 Packages: mkdirp 0.5.6
 
 Copyright 2010 James Halliday (mail@substack.net)
@@ -15988,7 +16292,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 285
+License text 295
 Packages: ms 2.1.3
 
 The MIT License (MIT)
@@ -16015,7 +16319,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 286
+License text 296
 Packages: mz 2.7.0
 
 The MIT License (MIT)
@@ -16042,7 +16346,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 287
+License text 297
 Packages: nanoid 3.3.16, 5.1.11
 
 The MIT License (MIT)
@@ -16068,7 +16372,33 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 288
+License text 298
+Packages: nanoid 3.3.16, 5.1.11
+
+The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+License text 299
 Packages: node-abi 4.33.0
 
 MIT License
@@ -16095,7 +16425,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 289
+License text 300
 Packages: node-gyp 12.4.0
 
 (The MIT License)
@@ -16125,7 +16455,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 290
+License text 301
 Packages: node-int64 0.4.0
 
 Copyright (c) 2014 Robert Kieffer
@@ -16150,7 +16480,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 291
+License text 302
 Packages: node-releases 2.0.38
 
 The MIT License
@@ -16177,7 +16507,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 292
+License text 303
 Packages: normalize-path 3.0.0
 
 The MIT License (MIT)
@@ -16204,7 +16534,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 293
+License text 304
 Packages: object-hash 3.0.0
 
 The MIT License (MIT)
@@ -16231,7 +16561,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 294
+License text 305
 Packages: object-inspect 1.13.4
 
 MIT License
@@ -16258,7 +16588,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 295
+License text 306
 Packages: object-keys 1.1.1
 
 The MIT License (MIT)
@@ -16285,7 +16615,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 296
+License text 307
 Packages: object.assign 4.1.7
 
 The MIT License (MIT)
@@ -16312,7 +16642,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 297
+License text 308
 Packages: obug 2.1.4
 
 The MIT License (MIT)
@@ -16341,7 +16671,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 298
+License text 309
 Packages: package-manager-detector 1.6.0
 
 MIT License
@@ -16368,7 +16698,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 299
+License text 310
 Packages: pako 1.0.11
 
 (The MIT License)
@@ -16395,7 +16725,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 300
+License text 311
 Packages: parse5 8.0.1
 
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
@@ -16420,7 +16750,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 301
+License text 312
 Packages: path-data-parser 0.1.0; points-on-curve 0.2.0
 
 MIT License
@@ -16447,7 +16777,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 302
+License text 313
 Packages: path-parse 1.0.7
 
 The MIT License (MIT)
@@ -16474,7 +16804,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 303
+License text 314
 Packages: pathe 2.0.3
 
 MIT License
@@ -16550,7 +16880,7 @@ DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 304
+License text 315
 Packages: pe-library 0.4.1; resedit 1.7.2
 
 MIT License
@@ -16577,7 +16907,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 305
+License text 316
 Packages: picocolors 1.1.1
 
 ISC License
@@ -16598,7 +16928,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 306
+License text 317
 Packages: picomatch 2.3.2, 4.0.4, 4.0.5
 
 The MIT License (MIT)
@@ -16625,7 +16955,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 307
+License text 318
 Packages: pirates 4.0.7
 
 MIT License
@@ -16652,7 +16982,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 308
+License text 319
 Packages: pkijs 3.4.0
 
 Copyright (c) 2014, GlobalSign
@@ -16688,7 +17018,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 309
+License text 320
 Packages: plist 3.1.0, 3.1.1
 
 (The MIT License)
@@ -16718,7 +17048,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 310
+License text 321
 Packages: points-on-path 0.2.1
 
 MIT License
@@ -16745,7 +17075,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 311
+License text 322
 Packages: postcss-import 15.1.0
 
 The MIT License (MIT)
@@ -16771,7 +17101,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 312
+License text 323
 Packages: postcss-js 4.1.0
 
 The MIT License (MIT)
@@ -16797,7 +17127,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 313
+License text 324
 Packages: postcss-load-config 6.0.1
 
 The MIT License (MIT)
@@ -16823,7 +17153,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 314
+License text 325
 Packages: postcss-nested 6.2.0
 
 The MIT License (MIT)
@@ -16849,7 +17179,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 315
+License text 326
 Packages: postcss-selector-parser 6.1.2
 
 Copyright (c) Ben Briggs <beneb.info@gmail.com> (http://beneb.info)
@@ -16877,7 +17207,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 316
+License text 327
 Packages: postcss-value-parser 4.2.0
 
 Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
@@ -16905,7 +17235,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 317
+License text 328
 Packages: proc-log 6.1.0
 
 The ISC License
@@ -16926,7 +17256,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 318
+License text 329
 Packages: process-nextick-args 2.0.1
 
 # Copyright (c) 2015 Calvin Metcalf
@@ -16951,7 +17281,7 @@ SOFTWARE.**
 
 ================================================================================
 
-License text 319
+License text 330
 Packages: progress 2.0.3
 
 (The MIT License)
@@ -16979,7 +17309,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 320
+License text 331
 Packages: promise-retry 2.0.1
 
 Copyright (c) 2014 IndigoUnited
@@ -17004,7 +17334,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 321
+License text 332
 Packages: prop-types 15.8.1
 
 MIT License
@@ -17031,7 +17361,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 322
+License text 333
 Packages: proxy-from-env 2.1.0
 
 The MIT License
@@ -17057,7 +17387,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 323
+License text 334
 Packages: pvtsutils 1.3.6
 
 MIT License
@@ -17084,7 +17414,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 324
+License text 335
 Packages: pvutils 1.1.5
 
 MIT License
@@ -17114,7 +17444,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 325
+License text 336
 Packages: queue-microtask 1.2.3; run-parallel 1.2.0
 
 The MIT License (MIT)
@@ -17140,7 +17470,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 326
+License text 337
 Packages: react 19.2.5; react-dom 19.2.5; scheduler 0.27.0; use-sync-external-store 1.6.0
 
 MIT License
@@ -17167,7 +17497,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 327
+License text 338
 Packages: react-dnd 16.0.1
 
 The MIT License (MIT)
@@ -17194,7 +17524,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 328
+License text 339
 Packages: react-hammerjs 1.0.1
 
 The MIT License (MIT)
@@ -17221,7 +17551,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 329
+License text 340
 Packages: react-hotkeys-hook 5.3.2
 
 MIT License
@@ -17248,7 +17578,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 330
+License text 341
 Packages: react-i18next 17.0.8
 
 The MIT License (MIT)
@@ -17275,7 +17605,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 331
+License text 342
 Packages: react-textarea-autosize 8.5.3
 
 The MIT License (MIT)
@@ -17301,7 +17631,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 332
+License text 343
 Packages: read-cache 1.0.0
 
 The MIT License (MIT)
@@ -17327,7 +17657,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 333
+License text 344
 Packages: readable-stream 2.3.8; string_decoder 1.1.1
 
 Node.js is licensed for use as follows:
@@ -17380,7 +17710,7 @@ IN THE SOFTWARE.
 
 ================================================================================
 
-License text 334
+License text 345
 Packages: readdirp 3.6.0, 4.1.2
 
 MIT License
@@ -17407,7 +17737,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 335
+License text 346
 Packages: redux 4.2.1
 
 The MIT License (MIT)
@@ -17434,7 +17764,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 336
+License text 347
 Packages: reflect.getprototypeof 1.0.10
 
 MIT License
@@ -17461,7 +17791,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 337
+License text 348
 Packages: regexp.prototype.flags 1.5.4
 
 The MIT License (MIT)
@@ -17488,7 +17818,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 338
+License text 349
 Packages: require-directory 2.1.1
 
 The MIT License (MIT)
@@ -17516,7 +17846,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 339
+License text 350
 Packages: require-from-string 2.0.2
 
 The MIT License (MIT)
@@ -17543,7 +17873,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 340
+License text 351
 Packages: resolve 1.22.12
 
 MIT License
@@ -17570,7 +17900,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 341
+License text 352
 Packages: responselike 2.0.1
 
 Copyright (c) 2017 Luke Childs
@@ -17595,7 +17925,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 342
+License text 353
 Packages: retry 0.12.0
 
 Copyright (c) 2011:
@@ -17622,7 +17952,7 @@ Felix Geisendörfer (felix@debuggable.com)
 
 ================================================================================
 
-License text 343
+License text 354
 Packages: reusify 1.1.0
 
 The MIT License (MIT)
@@ -17649,7 +17979,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 344
+License text 355
 Packages: robust-predicates 3.0.3
 
 This is free and unencumbered software released into the public domain.
@@ -17679,7 +18009,7 @@ For more information, please refer to <http://unlicense.org>
 
 ================================================================================
 
-License text 345
+License text 356
 Packages: roughjs 4.6.6
 
 MIT License
@@ -17706,7 +18036,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 346
+License text 357
 Packages: rw 1.3.3
 
 Copyright (c) 2014-2016, Michael Bostock
@@ -17738,7 +18068,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 347
+License text 358
 Packages: safe-buffer 5.1.2
 
 The MIT License (MIT)
@@ -17765,7 +18095,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 348
+License text 359
 Packages: safer-buffer 2.1.2
 
 MIT License
@@ -17792,7 +18122,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 349
+License text 360
 Packages: sanitize-filename 1.6.4
 
 This project is licensed under the [WTFPL][] and [ISC][] licenses.
@@ -17832,7 +18162,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 350
+License text 361
 Packages: sass 1.99.0
 
 Dart Sass license:
@@ -17988,7 +18318,7 @@ THE SOFTWARE.
 
 args, csslib and logging license:
 
-Copyright 2013, the Dart project authors. 
+Copyright 2013, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -18021,7 +18351,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 async, cli_util, collection, mime, stream_channel and typed_data license:
 
-Copyright 2015, the Dart project authors. 
+Copyright 2015, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -18454,7 +18784,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 coverage, dart_style, dartdoc, glob, http, http_parser, matcher, path, pool,
 pub_semver, source_span, string_scanner, test and watcher license:
 
-Copyright 2014, the Dart project authors. 
+Copyright 2014, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -18513,7 +18843,7 @@ SOFTWARE.
 
 ffi and package_config license:
 
-Copyright 2019, the Dart project authors. 
+Copyright 2019, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -18611,7 +18941,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 frontend_server_client license:
 
-Copyright 2020, the Dart project authors. 
+Copyright 2020, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -18707,7 +19037,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 io, stream_transform and term_glyph license:
 
-Copyright 2017, the Dart project authors. 
+Copyright 2017, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -18838,7 +19168,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 markdown license:
 
-Copyright 2012, the Dart project authors. 
+Copyright 2012, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -19343,7 +19673,7 @@ retry license:
 
 test_api and test_core license:
 
-Copyright 2018, the Dart project authors. 
+Copyright 2018, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -19376,7 +19706,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 test_descriptor and web_socket_channel license:
 
-Copyright 2016, the Dart project authors. 
+Copyright 2016, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -19474,7 +19804,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 web_socket license:
 
-Copyright 2024, the Dart project authors. 
+Copyright 2024, the Dart project authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -19558,7 +19888,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 351
+License text 362
 Packages: scroller 0.0.3
 
 Copyright (c) 2011 Zynga Inc., http://zynga.com/
@@ -19584,7 +19914,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 352
+License text 363
 Packages: setimmediate 1.0.5
 
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
@@ -19610,7 +19940,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 353
+License text 364
 Packages: shebang-command 2.0.0
 
 MIT License
@@ -19625,7 +19955,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 354
+License text 365
 Packages: siginfo 2.0.0
 
 Copyright (c) 2017, Emil Bay <github@tixz.dk>
@@ -19644,7 +19974,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 355
+License text 366
 Packages: signal-exit 3.0.7
 
 The ISC License
@@ -19666,7 +19996,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 356
+License text 367
 Packages: simple-update-notifier 2.0.0
 
 MIT License
@@ -19693,7 +20023,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 357
+License text 368
 Packages: sonner 2.0.7
 
 MIT License
@@ -19720,7 +20050,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 358
+License text 369
 Packages: source-map 0.6.1; source-map-js 1.2.1
 
 Copyright (c) 2009-2011, Mozilla Foundation and contributors
@@ -19753,7 +20083,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-License text 359
+License text 370
 Packages: source-map-support 0.5.21
 
 The MIT License (MIT)
@@ -19780,7 +20110,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 360
+License text 371
 Packages: stat-mode 1.0.0
 
 (The MIT License)
@@ -19810,7 +20140,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 361
+License text 372
 Packages: string.prototype.trimend 1.0.10; string.prototype.trimstart 1.0.8
 
 MIT License
@@ -19837,7 +20167,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 362
+License text 373
 Packages: style-mod 4.1.3
 
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
@@ -19862,7 +20192,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 363
+License text 374
 Packages: stylis 4.4.0
 
 MIT License
@@ -19889,7 +20219,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 364
+License text 375
 Packages: sucrase 3.35.1
 
 The MIT License (MIT)
@@ -19916,7 +20246,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 365
+License text 376
 Packages: symbol-tree 3.2.4
 
 The MIT License (MIT)
@@ -19943,7 +20273,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 366
+License text 377
 Packages: tailwind-merge 3.5.0
 
 MIT License
@@ -19970,7 +20300,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 367
+License text 378
 Packages: tailwindcss 3.4.19
 
 MIT License
@@ -19997,7 +20327,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 368
+License text 379
 Packages: tailwindcss-animate 1.0.7
 
 MIT License
@@ -20024,7 +20354,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 369
+License text 380
 Packages: temp 0.9.4
 
 The MIT License (MIT)
@@ -20050,7 +20380,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 370
+License text 381
 Packages: thenify 3.3.1
 
 The MIT License (MIT)
@@ -20077,7 +20407,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 371
+License text 382
 Packages: thenify-all 1.6.0
 
 The MIT License (MIT)
@@ -20104,7 +20434,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 372
+License text 383
 Packages: tiny-async-pool 1.3.0
 
 Copyright (c) 2017 Rafael Xavier de Souza http://rafael.xavier.blog.br
@@ -20132,7 +20462,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 373
+License text 384
 Packages: tiny-typed-emitter 2.1.0
 
 MIT License
@@ -20159,7 +20489,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 374
+License text 385
 Packages: tinybench 2.9.0; tinyrainbow 3.1.0
 
 MIT License
@@ -20186,7 +20516,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 375
+License text 386
 Packages: tinyexec 1.2.4
 
 MIT License
@@ -20213,7 +20543,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 376
+License text 387
 Packages: tinyglobby 0.2.16, 0.2.17
 
 MIT License
@@ -20240,7 +20570,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 377
+License text 388
 Packages: tldts 7.4.9; tldts-core 7.4.9
 
 Copyright (c) 2017 Thomas Parisot, 2018 Rémi Berson
@@ -20259,7 +20589,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTH
 
 ================================================================================
 
-License text 378
+License text 389
 Packages: tmp 0.2.7
 
 The MIT License (MIT)
@@ -20286,7 +20616,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 379
+License text 390
 Packages: to-regex-range 5.0.1
 
 The MIT License (MIT)
@@ -20313,7 +20643,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 380
+License text 391
 Packages: tough-cookie 6.0.2
 
 Copyright (c) 2015, Salesforce.com, Inc.
@@ -20331,7 +20661,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 ================================================================================
 
-License text 381
+License text 392
 Packages: tr46 6.0.0
 
 The MIT License (MIT)
@@ -20358,7 +20688,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 382
+License text 393
 Packages: ts-api-utils 2.5.0
 
 # MIT License
@@ -20384,7 +20714,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 383
+License text 394
 Packages: ts-dedent 2.2.0
 
 MIT License
@@ -20411,7 +20741,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 384
+License text 395
 Packages: ts-key-enum 2.0.12
 
 MIT License
@@ -20438,7 +20768,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 385
+License text 396
 Packages: ts-keycode-enum 1.0.6
 
 MIT License
@@ -20465,7 +20795,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 386
+License text 397
 Packages: tslib 2.8.1
 
 Copyright (c) Microsoft Corporation.
@@ -20483,7 +20813,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 387
+License text 398
 Packages: type-fest 0.20.2
 
 MIT License
@@ -20498,14 +20828,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 388
+License text 399
 Packages: typescript 6.0.3
 
 Apache License
 
 Version 2.0, January 2004
 
-http://www.apache.org/licenses/ 
+http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -20559,7 +20889,7 @@ END OF TERMS AND CONDITIONS
 
 ================================================================================
 
-License text 389
+License text 400
 Packages: undici 6.27.0, 7.28.0; undici-types 6.21.0, 7.18.2, 7.24.6, 8.3.0
 
 MIT License
@@ -20586,7 +20916,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 390
+License text 401
 Packages: universalify 0.1.2, 2.0.1
 
 (The MIT License)
@@ -20612,7 +20942,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 391
+License text 402
 Packages: unzipper 0.12.5
 
 Copyright (c) 2012 - 2013 Near Infinity Corporation
@@ -20643,7 +20973,7 @@ and fall under same licence structure as the original repo (MIT)
 
 ================================================================================
 
-License text 392
+License text 403
 Packages: update-browserslist-db 1.2.3
 
 The MIT License (MIT)
@@ -20669,7 +20999,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 393
+License text 404
 Packages: uri-js 4.4.1
 
 Copyright 2011 Gary Court. All rights reserved.
@@ -20686,7 +21016,7 @@ The views and conclusions contained in the software and documentation are those 
 
 ================================================================================
 
-License text 394
+License text 405
 Packages: use-isomorphic-layout-effect 1.2.1
 
 MIT License
@@ -20713,7 +21043,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 395
+License text 406
 Packages: use-latest 1.3.0
 
 MIT License
@@ -20740,7 +21070,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 396
+License text 407
 Packages: utf8-byte-length 1.0.5
 
 Copyright 2023 Carl Xiong & Parsha Pourkhomami
@@ -20753,26 +21083,26 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 ================================================================================
 
-License text 397
+License text 408
 Packages: utf8-byte-length 1.0.5
 
-DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-                    Version 2, December 2004 
+DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
 
- Copyright (C) 2004 Sam Hocevar <sam@hocevar.net> 
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
 
- Everyone is permitted to copy and distribute verbatim or modified 
- copies of this license document, and changing it is allowed as long 
- as the name is changed. 
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. You just DO WHAT THE FUCK YOU WANT TO.
 
 ================================================================================
 
-License text 398
+License text 409
 Packages: util-deprecate 1.0.2
 
 (The MIT License)
@@ -20802,7 +21132,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 399
+License text 410
 Packages: uuid 14.0.0
 
 The MIT License (MIT)
@@ -20817,7 +21147,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 400
+License text 411
 Packages: vaul 1.1.2
 
 MIT License
@@ -20832,7 +21162,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 
-License text 401
+License text 412
 Packages: vite 8.1.5
 
 # Vite core license
@@ -20871,17 +21201,17 @@ By: Justin Ridgewell
 Repositories: https://github.com/jridgewell/sourcemaps, https://github.com/jridgewell/sourcemaps, https://github.com/jridgewell/sourcemaps, https://github.com/jridgewell/sourcemaps
 
 > Copyright 2024 Justin Ridgewell <justin@ridgewell.name>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20898,17 +21228,17 @@ By: Justin Ridgewell
 Repository: https://github.com/jridgewell/resolve-uri
 
 > Copyright 2019 Justin Ridgewell <jridgewell@google.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20946,19 +21276,19 @@ By: Rich Harris
 Repository: https://github.com/rollup/plugins
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2019 RollupJS Plugin Contributors (https://github.com/rollup/plugins/graphs/contributors)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20977,17 +21307,17 @@ Repository: https://github.com/vercel/vercel
 > Apache License
 >                            Version 2.0, January 2004
 >                         http://www.apache.org/licenses/
-> 
+>
 >    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-> 
+>
 >    1. Definitions.
-> 
+>
 >       "License" shall mean the terms and conditions for use, reproduction,
 >       and distribution as defined by Sections 1 through 9 of this document.
-> 
+>
 >       "Licensor" shall mean the copyright owner or entity authorized by
 >       the copyright owner that is granting the License.
-> 
+>
 >       "Legal Entity" shall mean the union of the acting entity and all
 >       other entities that control, are controlled by, or are under common
 >       control with that entity. For the purposes of this definition,
@@ -20995,24 +21325,24 @@ Repository: https://github.com/vercel/vercel
 >       direction or management of such entity, whether by contract or
 >       otherwise, or (ii) ownership of fifty percent (50%) or more of the
 >       outstanding shares, or (iii) beneficial ownership of such entity.
-> 
+>
 >       "You" (or "Your") shall mean an individual or Legal Entity
 >       exercising permissions granted by this License.
-> 
+>
 >       "Source" form shall mean the preferred form for making modifications,
 >       including but not limited to software source code, documentation
 >       source, and configuration files.
-> 
+>
 >       "Object" form shall mean any form resulting from mechanical
 >       transformation or translation of a Source form, including but
 >       not limited to compiled object code, generated documentation,
 >       and conversions to other media types.
-> 
+>
 >       "Work" shall mean the work of authorship, whether in Source or
 >       Object form, made available under the License, as indicated by a
 >       copyright notice that is included in or attached to the work
 >       (an example is provided in the Appendix below).
-> 
+>
 >       "Derivative Works" shall mean any work, whether in Source or Object
 >       form, that is based on (or derived from) the Work and for which the
 >       editorial revisions, annotations, elaborations, or other modifications
@@ -21020,7 +21350,7 @@ Repository: https://github.com/vercel/vercel
 >       of this License, Derivative Works shall not include works that remain
 >       separable from, or merely link (or bind by name) to the interfaces of,
 >       the Work and Derivative Works thereof.
-> 
+>
 >       "Contribution" shall mean any work of authorship, including
 >       the original version of the Work and any modifications or additions
 >       to that Work or Derivative Works thereof, that is intentionally
@@ -21034,18 +21364,18 @@ Repository: https://github.com/vercel/vercel
 >       Licensor for the purpose of discussing and improving the Work, but
 >       excluding communication that is conspicuously marked or otherwise
 >       designated in writing by the copyright owner as "Not a Contribution."
-> 
+>
 >       "Contributor" shall mean Licensor and any individual or Legal Entity
 >       on behalf of whom a Contribution has been received by Licensor and
 >       subsequently incorporated within the Work.
-> 
+>
 >    2. Grant of Copyright License. Subject to the terms and conditions of
 >       this License, each Contributor hereby grants to You a perpetual,
 >       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
 >       copyright license to reproduce, prepare Derivative Works of,
 >       publicly display, publicly perform, sublicense, and distribute the
 >       Work and such Derivative Works in Source or Object form.
-> 
+>
 >    3. Grant of Patent License. Subject to the terms and conditions of
 >       this License, each Contributor hereby grants to You a perpetual,
 >       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
@@ -21061,24 +21391,24 @@ Repository: https://github.com/vercel/vercel
 >       or contributory patent infringement, then any patent licenses
 >       granted to You under this License for that Work shall terminate
 >       as of the date such litigation is filed.
-> 
+>
 >    4. Redistribution. You may reproduce and distribute copies of the
 >       Work or Derivative Works thereof in any medium, with or without
 >       modifications, and in Source or Object form, provided that You
 >       meet the following conditions:
-> 
+>
 >       (a) You must give any other recipients of the Work or
 >           Derivative Works a copy of this License; and
-> 
+>
 >       (b) You must cause any modified files to carry prominent notices
 >           stating that You changed the files; and
-> 
+>
 >       (c) You must retain, in the Source form of any Derivative Works
 >           that You distribute, all copyright, patent, trademark, and
 >           attribution notices from the Source form of the Work,
 >           excluding those notices that do not pertain to any part of
 >           the Derivative Works; and
-> 
+>
 >       (d) If the Work includes a "NOTICE" text file as part of its
 >           distribution, then any Derivative Works that You distribute must
 >           include a readable copy of the attribution notices contained
@@ -21095,14 +21425,14 @@ Repository: https://github.com/vercel/vercel
 >           or as an addendum to the NOTICE text from the Work, provided
 >           that such additional attribution notices cannot be construed
 >           as modifying the License.
-> 
+>
 >       You may add Your own copyright statement to Your modifications and
 >       may provide additional or different license terms and conditions
 >       for use, reproduction, or distribution of Your modifications, or
 >       for any such Derivative Works as a whole, provided Your use,
 >       reproduction, and distribution of the Work otherwise complies with
 >       the conditions stated in this License.
-> 
+>
 >    5. Submission of Contributions. Unless You explicitly state otherwise,
 >       any Contribution intentionally submitted for inclusion in the Work
 >       by You to the Licensor shall be under the terms and conditions of
@@ -21110,12 +21440,12 @@ Repository: https://github.com/vercel/vercel
 >       Notwithstanding the above, nothing herein shall supersede or modify
 >       the terms of any separate license agreement you may have executed
 >       with Licensor regarding such Contributions.
-> 
+>
 >    6. Trademarks. This License does not grant permission to use the trade
 >       names, trademarks, service marks, or product names of the Licensor,
 >       except as required for reasonable and customary use in describing the
 >       origin of the Work and reproducing the content of the NOTICE file.
-> 
+>
 >    7. Disclaimer of Warranty. Unless required by applicable law or
 >       agreed to in writing, Licensor provides the Work (and each
 >       Contributor provides its Contributions) on an "AS IS" BASIS,
@@ -21125,7 +21455,7 @@ Repository: https://github.com/vercel/vercel
 >       PARTICULAR PURPOSE. You are solely responsible for determining the
 >       appropriateness of using or redistributing the Work and assume any
 >       risks associated with Your exercise of permissions under this License.
-> 
+>
 >    8. Limitation of Liability. In no event and under no legal theory,
 >       whether in tort (including negligence), contract, or otherwise,
 >       unless required by applicable law (such as deliberate and grossly
@@ -21137,7 +21467,7 @@ Repository: https://github.com/vercel/vercel
 >       work stoppage, computer failure or malfunction, or any and all
 >       other commercial damages or losses), even if such Contributor
 >       has been advised of the possibility of such damages.
-> 
+>
 >    9. Accepting Warranty or Additional Liability. While redistributing
 >       the Work or Derivative Works thereof, You may choose to offer,
 >       and charge a fee for, acceptance of support, warranty, indemnity,
@@ -21148,11 +21478,11 @@ Repository: https://github.com/vercel/vercel
 >       defend, and hold each Contributor harmless for any liability
 >       incurred by, or claims asserted against, such Contributor by reason
 >       of your accepting any such warranty or additional liability.
-> 
+>
 >    END OF TERMS AND CONDITIONS
-> 
+>
 >    APPENDIX: How to apply the Apache License to your work.
-> 
+>
 >       To apply the Apache License to your work, attach the following
 >       boilerplate notice, with the fields enclosed by brackets "[]"
 >       replaced with your own identifying information. (Don't include
@@ -21161,15 +21491,15 @@ Repository: https://github.com/vercel/vercel
 >       file or class name and description of purpose be included on the
 >       same "printed page" as the copyright notice for easier
 >       identification within third-party archives.
-> 
+>
 >    Copyright 2017 Vercel, Inc.
-> 
+>
 >    Licensed under the Apache License, Version 2.0 (the "License");
 >    you may not use this file except in compliance with the License.
 >    You may obtain a copy of the License at
-> 
+>
 >        http://www.apache.org/licenses/LICENSE-2.0
-> 
+>
 >    Unless required by applicable law or agreed to in writing, software
 >    distributed under the License is distributed on an "AS IS" BASIS,
 >    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21183,19 +21513,19 @@ License: MIT
 Repository: https://github.com/vitest-dev/vitest
 
 > MIT License
-> 
+>
 > Copyright (c) 2021-Present VoidZero Inc. and Vitest contributors
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21211,19 +21541,19 @@ License: MIT
 Repository: https://github.com/voidzero-dev/vite-task
 
 > MIT License
-> 
+>
 > Copyright (c) 2026-present, VoidZero Inc.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21240,13 +21570,13 @@ By: Elan Shanker
 Repository: https://github.com/micromatch/anymatch
 
 > The ISC License
-> 
+>
 > Copyright (c) 2019 Elan Shanker, Paul Miller (https://paulmillr.com)
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -21263,20 +21593,20 @@ By: sapphi-red, Evan You
 Repository: https://github.com/sapphi-red/artichokie
 
 > MIT License
-> 
+>
 > Copyright (c) 2020-present, Yuxi (Evan) You
 > Copyright (c) 2023-present, sapphi-red
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21293,14 +21623,14 @@ By: Sindre Sorhus
 Repository: https://github.com/sindresorhus/binary-extensions
 
 > MIT License
-> 
+>
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 > Copyright (c) Paul Miller (https://paulmillr.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -21319,19 +21649,19 @@ By: Jon Schlinkert, Olsten Larck, Rouven Weßling
 Repository: https://github.com/jonschlinkert/is-number
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014-present, Jon Schlinkert.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21348,13 +21678,13 @@ By: Sindre Sorhus
 Repositories: https://github.com/sindresorhus/bundle-name, https://github.com/sindresorhus/default-browser, https://github.com/sindresorhus/default-browser-id, https://github.com/sindresorhus/define-lazy-prop, https://github.com/sindresorhus/is-docker, https://github.com/sindresorhus/is-inside-container, https://github.com/sindresorhus/is-wsl, https://github.com/sindresorhus/open, https://github.com/sindresorhus/run-applescript, https://github.com/sindresorhus/wsl-utils
 
 > MIT License
-> 
+>
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -21365,19 +21695,19 @@ By: egoist
 Repository: https://github.com/cacjs/cac
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) EGOIST <0x142857@gmail.com> (https://github.com/egoist)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21394,19 +21724,19 @@ By: Paul Miller, Elan Shanker
 Repository: https://github.com/paulmillr/chokidar
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2012-2019 Paul Miller (https://paulmillr.com), Elan Shanker
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the “Software”), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21423,12 +21753,12 @@ By: TJ Holowaychuk, Douglas Christopher Wilson, Jonathan Ong, Tim Caswell
 Repository: https://github.com/senchalabs/connect
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2010 Sencha Inc.
 > Copyright (c) 2011 LearnBoost
 > Copyright (c) 2011-2014 TJ Holowaychuk
 > Copyright (c) 2015 Douglas Christopher Wilson
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -21436,10 +21766,10 @@ Repository: https://github.com/senchalabs/connect
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -21455,9 +21785,9 @@ License: MIT
 By: Thorsten Lorenz
 Repository: https://github.com/thlorenz/convert-source-map
 
-> Copyright 2013 Thorsten Lorenz. 
+> Copyright 2013 Thorsten Lorenz.
 > All rights reserved.
-> 
+>
 > Permission is hereby granted, free of charge, to any person
 > obtaining a copy of this software and associated documentation
 > files (the "Software"), to deal in the Software without
@@ -21466,10 +21796,10 @@ Repository: https://github.com/thlorenz/convert-source-map
 > copies of the Software, and to permit persons to whom the
 > Software is furnished to do so, subject to the following
 > conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 > OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -21487,9 +21817,9 @@ By: Troy Goode
 Repository: https://github.com/expressjs/cors
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2013 Troy Goode <troygoode@gmail.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -21497,10 +21827,10 @@ Repository: https://github.com/expressjs/cors
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -21517,19 +21847,19 @@ By: André Cruz
 Repository: https://github.com/moxystudio/node-cross-spawn
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2018 Made With MOXY Lda <hello@moxy.studio>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21546,7 +21876,7 @@ By: Mathias Bynens
 Repository: https://github.com/mathiasbynens/cssesc
 
 > Copyright Mathias Bynens <https://mathiasbynens.be/>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > "Software"), to deal in the Software without restriction, including
@@ -21554,10 +21884,10 @@ Repository: https://github.com/mathiasbynens/cssesc
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -21575,17 +21905,17 @@ Repository: https://github.com/motdotla/dotenv-expand
 
 > Copyright (c) 2016, Scott Motte
 > All rights reserved.
-> 
+>
 > Redistribution and use in source and binary forms, with or without
 > modification, are permitted provided that the following conditions are met:
-> 
+>
 > * Redistributions of source code must retain the above copyright notice, this
 >   list of conditions and the following disclaimer.
-> 
+>
 > * Redistributions in binary form must reproduce the above copyright notice,
 >   this list of conditions and the following disclaimer in the documentation
 >   and/or other materials provided with the distribution.
-> 
+>
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 > AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 > IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -21605,19 +21935,19 @@ By: Jonathan Ong, Douglas Christopher Wilson
 Repository: https://github.com/jonathanong/ee-first
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014 Jonathan Ong me@jongleberry.com
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21634,9 +21964,9 @@ By: Douglas Christopher Wilson
 Repository: https://github.com/pillarjs/encodeurl
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2016 Douglas Christopher Wilson
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -21644,10 +21974,10 @@ Repository: https://github.com/pillarjs/encodeurl
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -21665,13 +21995,13 @@ Repository: https://github.com/fb55/entities
 
 > Copyright (c) Felix Böhm
 > All rights reserved.
-> 
+>
 > Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-> 
+>
 > Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-> 
+>
 > Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-> 
+>
 > THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
 > EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
@@ -21684,13 +22014,13 @@ Repository: https://github.com/guybedford/es-module-lexer
 
 > MIT License
 > -----------
-> 
+>
 > Copyright (C) 2018-2022 Guy Bedford
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -21700,11 +22030,11 @@ License: MIT
 Repository: https://github.com/component/escape-html
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2012-2013 TJ Holowaychuk
 > Copyright (c) 2015 Andreas Lubbe
 > Copyright (c) 2015 Tiancheng "Timothy" Gu
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -21712,10 +22042,10 @@ Repository: https://github.com/component/escape-html
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -21732,11 +22062,11 @@ By: Rich Harris
 Repository: https://github.com/Rich-Harris/estree-walker
 
 > Copyright (c) 2015-20 [these people](https://github.com/Rich-Harris/estree-walker/graphs/contributors)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -21747,9 +22077,9 @@ By: Douglas Christopher Wilson, David Björklund
 Repository: https://github.com/jshttp/etag
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2014-2016 Douglas Christopher Wilson
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -21757,10 +22087,10 @@ Repository: https://github.com/jshttp/etag
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -21777,9 +22107,9 @@ By: Douglas Christopher Wilson
 Repository: https://github.com/pillarjs/finalhandler
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -21787,10 +22117,10 @@ Repository: https://github.com/pillarjs/finalhandler
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -21807,17 +22137,17 @@ By: Ruben Verborgh, Olivier Lalonde, James Talmage
 Repository: https://github.com/follow-redirects/follow-redirects
 
 > Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 > of the Software, and to permit persons to whom the Software is furnished to do
 > so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21833,19 +22163,19 @@ By: sapphi-red
 Repository: https://github.com/sapphi-red/fresh-import
 
 > MIT License
-> 
+>
 > Copyright (c) 2026 sapphi-red
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21862,19 +22192,19 @@ By: Alexey Litvinov
 Repository: https://github.com/css-modules/generic-names
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2015 Alexey Litvinov
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21891,13 +22221,13 @@ By: Gulp Team, Elan Shanker, Blaine Bublitz
 Repository: https://github.com/gulpjs/glob-parent
 
 > The ISC License
-> 
+>
 > Copyright (c) 2015, 2019 Elan Shanker
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -21914,19 +22244,19 @@ By: sapphi-red
 Repository: https://github.com/sapphi-red/host-validation-middleware
 
 > MIT License
-> 
+>
 > Copyright (c) 2025 sapphi-red
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21943,9 +22273,9 @@ By: William Stein, Charlie Robbins, Jimb Esser, jcrugzz
 Repository: https://github.com/sagemathinc/http-proxy-3
 
 > node-http-3
-> 
+>
 > Copyright (c) 2010-2025 William Stein, Charlie Robbins, Jarrett Cruger & the Contributors.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > "Software"), to deal in the Software without restriction, including
@@ -21953,10 +22283,10 @@ Repository: https://github.com/sagemathinc/http-proxy-3
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -21974,9 +22304,9 @@ Repository: https://github.com/css-modules/icss-utils
 
 > ISC License (ISC)
 > Copyright 2018 Glen Maddern
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
@@ -21987,13 +22317,13 @@ By: Sindre Sorhus
 Repository: https://github.com/sindresorhus/is-binary-path
 
 > MIT License
-> 
+>
 > Copyright (c) 2019 Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com), Paul Miller (https://paulmillr.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -22004,19 +22334,19 @@ By: Jon Schlinkert
 Repository: https://github.com/jonschlinkert/is-extglob
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014-2016, Jon Schlinkert
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22033,19 +22363,19 @@ By: Jon Schlinkert, Brian Woodward, Daniel Perez
 Repository: https://github.com/micromatch/is-glob
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014-2017, Jon Schlinkert.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22062,13 +22392,13 @@ By: Isaac Z. Schlueter
 Repositories: https://github.com/isaacs/isexe, https://github.com/isaacs/node-which
 
 > The ISC License
-> 
+>
 > Copyright (c) Isaac Z. Schlueter and Contributors
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -22085,19 +22415,19 @@ By: Simon Lydell
 Repository: https://github.com/lydell/js-tokens
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 Simon Lydell
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22114,19 +22444,19 @@ By: Evan You
 Repositories: https://github.com/vitejs/launch-editor, https://github.com/vitejs/launch-editor
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2017-present, Yuxi (Evan) You
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22143,19 +22473,19 @@ By: antonk52
 Repository: https://github.com/antonk52/lilconfig
 
 > MIT License
-> 
+>
 > Copyright (c) 2022 Anton Kastritskiy
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22172,7 +22502,7 @@ By: Tobias Koppers @sokra
 Repository: https://github.com/webpack/loader-utils
 
 > Copyright JS Foundation and other contributors
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -22180,10 +22510,10 @@ Repository: https://github.com/webpack/loader-utils
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -22200,19 +22530,19 @@ By: John-David Dalton, Blaine Bublitz, Mathias Bynens
 Repository: https://github.com/lodash/lodash
 
 > Copyright jQuery Foundation and other contributors <https://jquery.org/>
-> 
+>
 > Based on Underscore.js, copyright Jeremy Ashkenas,
 > DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-> 
+>
 > This software consists of voluntary contributions made by many
 > individuals. For exact contribution history, see the revision history
 > available at https://github.com/lodash/lodash
-> 
+>
 > The following license applies to all parts of this software except as
 > documented below:
-> 
+>
 > ====
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > "Software"), to deal in the Software without restriction, including
@@ -22220,10 +22550,10 @@ Repository: https://github.com/lodash/lodash
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22231,17 +22561,17 @@ Repository: https://github.com/lodash/lodash
 > LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-> 
+>
 > ====
-> 
+>
 > Copyright and related rights for sample code are waived via CC0. Sample
 > code is defined as all source code displayed within the prose of the
 > documentation.
-> 
+>
 > CC0: http://creativecommons.org/publicdomain/zero/1.0/
-> 
+>
 > ====
-> 
+>
 > Files located in the node_modules and vendor directories are externally
 > maintained libraries used by this software which have their own
 > licenses; we recommend you read them, as their terms may differ from the
@@ -22255,11 +22585,11 @@ By: Rich Harris
 Repository: https://github.com/Rich-Harris/magic-string
 
 > Copyright 2018 Rich Harris
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -22269,19 +22599,19 @@ License: MIT
 Repositories: https://github.com/unjs/mlly, https://github.com/unjs/ufo
 
 > MIT License
-> 
+>
 > Copyright (c) Pooya Parsa <pooya@pi0.io>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22298,19 +22628,19 @@ By: Luke Edwards
 Repository: https://github.com/lukeed/mrmime
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (https://lukeed.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22327,19 +22657,19 @@ By: Jon Schlinkert, Blaine Bublitz
 Repository: https://github.com/jonschlinkert/normalize-path
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014-2018, Jon Schlinkert.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22356,19 +22686,19 @@ By: Sindre Sorhus
 Repository: https://github.com/sindresorhus/object-assign
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22385,21 +22715,21 @@ By: Kevin Deng
 Repository: https://github.com/sxzz/obug
 
 > The MIT License (MIT)
-> 
+>
 > Copyright © 2025-PRESENT Kevin Deng (https://github.com/sxzz)
 > Copyright (c) 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
 > Copyright (c) 2018-2021 Josh Junon
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22416,10 +22746,10 @@ By: Douglas Christopher Wilson, Jonathan Ong
 Repository: https://github.com/jshttp/on-finished
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
 > Copyright (c) 2014 Douglas Christopher Wilson <doug@somethingdoug.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -22427,10 +22757,10 @@ Repository: https://github.com/jshttp/on-finished
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -22447,17 +22777,17 @@ By: Ivan Nikulin, James Garbutt, Felix Boehm, Titus
 Repository: https://github.com/inikulin/parse5
 
 > Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22474,10 +22804,10 @@ By: Douglas Christopher Wilson, Jonathan Ong
 Repository: https://github.com/pillarjs/parseurl
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
 > Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -22485,10 +22815,10 @@ Repository: https://github.com/pillarjs/parseurl
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -22505,13 +22835,13 @@ By: Sindre Sorhus
 Repositories: https://github.com/sindresorhus/path-key, https://github.com/sindresorhus/shebang-regex
 
 > MIT License
-> 
+>
 > Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -22521,11 +22851,11 @@ License: MIT
 Repository: https://github.com/Rich-Harris/periscopic
 
 > Copyright (c) 2019 Rich Harris
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -22536,13 +22866,13 @@ By: Alexey Raspopov
 Repository: https://github.com/alexeyraspopov/picocolors
 
 > ISC License
-> 
+>
 > Copyright (c) 2021-2024 Oleksii Raspopov, Kostiantyn Denysov, Anton Verinov
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
 > copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 > WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 > MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -22559,19 +22889,19 @@ By: Maxime Thirouin
 Repository: https://github.com/postcss/postcss-import
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014 Maxime Thirouin, Jason Campbell & Kevin Mårtensson
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -22587,19 +22917,19 @@ By: Michael Ciniawky, Ryan Dunckel, Mateusz Derks, Dalton Santos, Patrick Gilday
 Repository: https://github.com/postcss/postcss-load-config
 
 > The MIT License (MIT)
-> 
+>
 > Copyright Michael Ciniawsky <michael.ciniawsky@gmail.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -22615,19 +22945,19 @@ By: Alexander Madyankin
 Repository: https://github.com/css-modules/postcss-modules
 
 > The MIT License (MIT)
-> 
+>
 > Copyright 2015-present Alexander Madyankin <alexander@madyankin.name>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -22643,9 +22973,9 @@ By: Glen Maddern
 Repository: https://github.com/css-modules/postcss-modules-extract-imports
 
 > Copyright 2015 Glen Maddern
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
@@ -22656,19 +22986,19 @@ By: Mark Dalgleish
 Repository: https://github.com/css-modules/postcss-modules-local-by-default
 
 > The MIT License (MIT)
-> 
+>
 > Copyright 2015 Mark Dalgleish <mark.john.dalgleish@gmail.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -22684,11 +23014,11 @@ By: Glen Maddern
 Repository: https://github.com/css-modules/postcss-modules-scope
 
 > ISC License (ISC)
-> 
+>
 > Copyright (c) 2015, Glen Maddern
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
@@ -22699,11 +23029,11 @@ By: Glen Maddern
 Repository: https://github.com/css-modules/postcss-modules-values
 
 > ISC License (ISC)
-> 
+>
 > Copyright (c) 2015, Glen Maddern
-> 
+>
 > Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
@@ -22714,7 +23044,7 @@ By: Ben Briggs, Chris Eppstein
 Repository: https://github.com/postcss/postcss-selector-parser
 
 > Copyright (c) Ben Briggs <beneb.info@gmail.com> (http://beneb.info)
-> 
+>
 > Permission is hereby granted, free of charge, to any person
 > obtaining a copy of this software and associated documentation
 > files (the "Software"), to deal in the Software without
@@ -22723,10 +23053,10 @@ Repository: https://github.com/postcss/postcss-selector-parser
 > copies of the Software, and to permit persons to whom the
 > Software is furnished to do so, subject to the following
 > conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 > OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22744,7 +23074,7 @@ By: Bogdan Chadkin
 Repository: https://github.com/TrySound/postcss-value-parser
 
 > Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
-> 
+>
 > Permission is hereby granted, free of charge, to any person
 > obtaining a copy of this software and associated documentation
 > files (the "Software"), to deal in the Software without
@@ -22753,10 +23083,10 @@ Repository: https://github.com/TrySound/postcss-value-parser
 > copies of the Software, and to permit persons to whom the
 > Software is furnished to do so, subject to the following
 > conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 > OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22774,19 +23104,19 @@ By: Thorsten Lorenz, Paul Miller
 Repository: https://github.com/paulmillr/readdirp
 
 > MIT License
-> 
+>
 > Copyright (c) 2012-2019 Thorsten Lorenz, Paul Miller (https://paulmillr.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22803,19 +23133,19 @@ By: Luke Edwards
 Repositories: https://github.com/lukeed/resolve.exports, https://github.com/lukeed/totalist
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22832,13 +23162,13 @@ By: Kevin Mårtensson
 Repository: https://github.com/kevva/shebang-command
 
 > MIT License
-> 
+>
 > Copyright (c) Kevin Mårtensson <kevinmartensson@gmail.com> (github.com/kevva)
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -22849,28 +23179,28 @@ By: James Halliday
 Repository: http://github.com/ljharb/shell-quote
 
 > The MIT License
-> 
+>
 > Copyright (c) 2013 James Halliday (mail@substack.net)
-> 
-> Permission is hereby granted, free of charge, 
-> to any person obtaining a copy of this software and 
-> associated documentation files (the "Software"), to 
-> deal in the Software without restriction, including 
-> without limitation the rights to use, copy, modify, 
-> merge, publish, distribute, sublicense, and/or sell 
-> copies of the Software, and to permit persons to whom 
-> the Software is furnished to do so, 
+>
+> Permission is hereby granted, free of charge,
+> to any person obtaining a copy of this software and
+> associated documentation files (the "Software"), to
+> deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify,
+> merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom
+> the Software is furnished to do so,
 > subject to the following conditions:
-> 
-> The above copyright notice and this permission notice 
+>
+> The above copyright notice and this permission notice
 > shall be included in all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-> OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
-> ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+> OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+> ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 > SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -22888,20 +23218,20 @@ By: Douglas Christopher Wilson, Jonathan Ong
 Repository: https://github.com/jshttp/statuses
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
 > Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22925,19 +23255,19 @@ By: Anthony Fu
 Repository: https://github.com/antfu/strip-literal
 
 > MIT License
-> 
+>
 > Copyright (c) 2022 Anthony Fu <https://github.com/antfu>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22954,19 +23284,19 @@ By: Jon Schlinkert, Rouven Weßling
 Repository: https://github.com/micromatch/to-regex-range
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2015-present, Jon Schlinkert.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in
 > all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22983,9 +23313,9 @@ By: Douglas Christopher Wilson
 Repository: https://github.com/stream-utils/unpipe
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -22993,10 +23323,10 @@ Repository: https://github.com/stream-utils/unpipe
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -23013,9 +23343,9 @@ By: Nathan Rajlich
 Repository: https://github.com/TooTallNate/util-deprecate
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
-> 
+>
 > Permission is hereby granted, free of charge, to any person
 > obtaining a copy of this software and associated documentation
 > files (the "Software"), to deal in the Software without
@@ -23024,10 +23354,10 @@ Repository: https://github.com/TooTallNate/util-deprecate
 > copies of the Software, and to permit persons to whom the
 > Software is furnished to do so, subject to the following
 > conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 > OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -23045,19 +23375,19 @@ By: Jared Hanson
 Repository: https://github.com/jaredhanson/utils-merge
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2013-2017 Jared Hanson
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -23073,9 +23403,9 @@ By: Douglas Christopher Wilson
 Repository: https://github.com/jshttp/vary
 
 > (The MIT License)
-> 
+>
 > Copyright (c) 2014-2017 Douglas Christopher Wilson
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
 > 'Software'), to deal in the Software without restriction, including
@@ -23083,10 +23413,10 @@ Repository: https://github.com/jshttp/vary
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -23105,17 +23435,17 @@ Repository: https://github.com/websockets/ws
 > Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 > Copyright (c) 2013 Arnout Kazemier and contributors
 > Copyright (c) 2016 Luigi Pinca and contributors
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy of
 > this software and associated documentation files (the "Software"), to deal in
 > the Software without restriction, including without limitation the rights to
 > use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 > the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 > FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -23125,7 +23455,7 @@ Repository: https://github.com/websockets/ws
 
 ================================================================================
 
-License text 402
+License text 413
 Packages: vitest 4.1.10
 
 # Vitest core license
@@ -23942,7 +24272,7 @@ Repository: git+https://github.com/websockets/ws.git
 
 ================================================================================
 
-License text 403
+License text 414
 Packages: void-elements 3.1.0
 
 (The MIT License)
@@ -23970,7 +24300,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 404
+License text 415
 Packages: w3c-keyname 2.2.8
 
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
@@ -23995,7 +24325,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 405
+License text 416
 Packages: w3c-xmlserializer 5.0.0
 
 The MIT License (MIT)
@@ -24026,7 +24356,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 406
+License text 417
 Packages: webcrypto-core 1.9.2
 
 The MIT License (MIT)
@@ -24053,7 +24383,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 407
+License text 418
 Packages: webidl-conversions 8.0.1
 
 # The BSD 2-Clause License
@@ -24071,7 +24401,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 ================================================================================
 
-License text 408
+License text 419
 Packages: whatwg-url 16.0.1
 
 The MIT License (MIT)
@@ -24098,7 +24428,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 409
+License text 420
 Packages: which-builtin-type 1.2.1
 
 MIT License
@@ -24125,7 +24455,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 410
+License text 421
 Packages: why-is-node-running 2.3.0
 
 The MIT License (MIT)
@@ -24152,7 +24482,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 411
+License text 422
 Packages: xml 1.0.1
 
 (The MIT License)
@@ -24180,7 +24510,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 412
+License text 423
 Packages: xml-js 1.6.11
 
 The MIT License (MIT)
@@ -24207,7 +24537,7 @@ SOFTWARE.
 
 ================================================================================
 
-License text 413
+License text 424
 Packages: xml-name-validator 5.0.0
 
 Apache License
@@ -24389,7 +24719,7 @@ Apache License
 
 ================================================================================
 
-License text 414
+License text 425
 Packages: xmlbuilder 15.1.1
 
 The MIT License (MIT)
@@ -24416,7 +24746,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 415
+License text 426
 Packages: xmlchars 2.2.0
 
 Copyright Louis-Dominique Dubeau and contributors to xmlchars
@@ -24440,7 +24770,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
-License text 416
+License text 427
 Packages: y18n 5.0.8
 
 Copyright (c) 2015, Contributors
@@ -24459,7 +24789,7 @@ THIS SOFTWARE.
 
 ================================================================================
 
-License text 417
+License text 428
 Packages: yargs 17.7.2
 
 MIT License
@@ -24486,7 +24816,7 @@ THE SOFTWARE.
 
 ================================================================================
 
-License text 418
+License text 429
 Packages: yargs-parser 21.1.1
 
 Copyright (c) 2016, Contributors
@@ -24506,7 +24836,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ================================================================================
 
-License text 419
+License text 430
 Packages: zod 4.1.13
 
 MIT License

--- a/electron/scripts/validate-desktop-renderer.mjs
+++ b/electron/scripts/validate-desktop-renderer.mjs
@@ -20,6 +20,7 @@ function collectLocalAssetReferences(html) {
 export async function validateDesktopRenderer({ rootDir = appDir } = {}) {
   const distDir = path.join(rootDir, 'dist')
   const indexPath = path.join(distDir, 'index.html')
+  const logoMarkPath = path.join(distDir, 'logo-mark.png')
   const html = await fs.readFile(indexPath, 'utf8')
   const references = collectLocalAssetReferences(html)
   const absoluteReferences = references.filter((value) => value.startsWith('/'))
@@ -48,6 +49,24 @@ export async function validateDesktopRenderer({ rootDir = appDir } = {}) {
 
   if (!references.some((value) => /\.m?js(?:[?#]|$)/.test(value))) {
     throw new Error('desktop renderer does not reference a JavaScript entry asset')
+  }
+
+  try {
+    const logoMark = await fs.stat(logoMarkPath)
+    if (!logoMark.isFile()) throw new Error('not a file')
+  } catch {
+    throw new Error('desktop renderer is missing logo-mark.png')
+  }
+
+  const assetEntries = await fs.readdir(path.join(distDir, 'assets'), { withFileTypes: true })
+  const rendererBundles = assetEntries
+    .filter((entry) => entry.isFile() && /\.(?:css|m?js)$/.test(entry.name))
+    .map((entry) => path.join(distDir, 'assets', entry.name))
+  for (const bundlePath of rendererBundles) {
+    const bundle = await fs.readFile(bundlePath, 'utf8')
+    if (/["'`]\/logo-mark\.png(?:[?#][^"'`]*)?["'`]/.test(bundle)) {
+      throw new Error('desktop renderer contains a root-relative logo-mark.png reference')
+    }
   }
 
   console.log(`[desktop-renderer] verified ${references.length} relative asset references`)

--- a/electron/scripts/validate-desktop-renderer.spec.ts
+++ b/electron/scripts/validate-desktop-renderer.spec.ts
@@ -18,6 +18,7 @@ async function createFixture(indexHtml: string) {
   await fs.writeFile(path.join(rootDir, 'dist', 'index.html'), indexHtml)
   await fs.writeFile(path.join(rootDir, 'dist', 'assets', 'app.js'), 'export {}')
   await fs.writeFile(path.join(rootDir, 'dist', 'assets', 'app.css'), '')
+  await fs.writeFile(path.join(rootDir, 'dist', 'logo-mark.png'), '')
   return rootDir
 }
 
@@ -47,6 +48,18 @@ describe('validateDesktopRenderer', () => {
 
     await expect(validateDesktopRenderer({ rootDir })).rejects.toThrow(
       'references missing assets: ./assets/missing.js',
+    )
+  })
+
+  it('rejects a root-relative logo reference hidden inside a JavaScript bundle', async () => {
+    const rootDir = await createFixture('<script type="module" src="./assets/app.js"></script>')
+    await fs.writeFile(
+      path.join(rootDir, 'dist', 'assets', 'app.js'),
+      'export const logo = "/logo-mark.png"',
+    )
+
+    await expect(validateDesktopRenderer({ rootDir })).rejects.toThrow(
+      'root-relative logo-mark.png reference',
     )
   })
 })

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -9,6 +9,12 @@ const outputPath = path.join(repositoryDir, 'docs/legal/THIRD_PARTY_NOTICES.txt'
 const packageManager = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const divider = '='.repeat(80)
 
+function compareText(left, right) {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
 function loadLicenseInventory() {
   const result = spawnSync(packageManager, ['licenses', 'list', '--no-optional', '--json'], {
     cwd: repositoryDir,
@@ -21,8 +27,67 @@ function loadLicenseInventory() {
   return JSON.parse(result.stdout)
 }
 
-function packageFallbackPath(name) {
-  return path.join(repositoryDir, 'node_modules', ...name.split('/'))
+function packageIndexKey(name, version) {
+  return `${name}\0${version}`
+}
+
+function readPackageIdentity(packagePath) {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(packagePath, 'package.json'), 'utf8'))
+    if (typeof manifest.name !== 'string' || typeof manifest.version !== 'string') return null
+    return { name: manifest.name, version: manifest.version }
+  } catch {
+    return null
+  }
+}
+
+function listPackagePaths(nodeModulesPath) {
+  if (!fs.existsSync(nodeModulesPath)) return []
+  const packagePaths = []
+  for (const entry of fs.readdirSync(nodeModulesPath, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue
+    const entryPath = path.join(nodeModulesPath, entry.name)
+    if (entry.name.startsWith('@')) {
+      if (!fs.existsSync(entryPath)) continue
+      for (const scopedEntry of fs.readdirSync(entryPath, { withFileTypes: true })) {
+        packagePaths.push(path.join(entryPath, scopedEntry.name))
+      }
+      continue
+    }
+    packagePaths.push(entryPath)
+  }
+  return packagePaths
+}
+
+function buildInstalledPackageIndex() {
+  const index = new Map()
+  const pendingNodeModules = [path.join(repositoryDir, 'node_modules')]
+  const visitedNodeModules = new Set()
+
+  while (pendingNodeModules.length) {
+    const nodeModulesPath = pendingNodeModules.pop()
+    if (!nodeModulesPath || !fs.existsSync(nodeModulesPath)) continue
+    let realNodeModulesPath
+    try {
+      realNodeModulesPath = fs.realpathSync(nodeModulesPath)
+    } catch {
+      continue
+    }
+    if (visitedNodeModules.has(realNodeModulesPath)) continue
+    visitedNodeModules.add(realNodeModulesPath)
+
+    for (const packagePath of listPackagePaths(nodeModulesPath)) {
+      const identity = readPackageIdentity(packagePath)
+      if (!identity) continue
+      const key = packageIndexKey(identity.name, identity.version)
+      const paths = index.get(key) || []
+      paths.push(packagePath)
+      index.set(key, paths)
+      pendingNodeModules.push(path.join(packagePath, 'node_modules'))
+    }
+  }
+
+  return index
 }
 
 function findLicenseFiles(packagePath) {
@@ -33,29 +98,32 @@ function findLicenseFiles(packagePath) {
     .readdirSync(packagePath, { withFileTypes: true })
     .filter((entry) => entry.isFile() && /^(licen[cs]e|copying|copyright|notice)(?:[._-].*)?$/i.test(entry.name))
     .map((entry) => path.join(packagePath, entry.name))
-    .sort((left, right) => left.localeCompare(right))
+    .sort(compareText)
 }
 
-function readLicenseTexts(entry) {
-  const packagePaths = [...new Set([...(entry.paths || []), packageFallbackPath(entry.name)])]
-  const texts = []
+function readLicenseTexts(entry, installedPackageIndex) {
+  const packagePaths = entry.versions.flatMap((version) => (
+    installedPackageIndex.get(packageIndexKey(entry.name, version)) || []
+  ))
   const seen = new Set()
   for (const packagePath of packagePaths) {
     for (const licensePath of findLicenseFiles(packagePath)) {
-      const text = fs.readFileSync(licensePath, 'utf8').replace(/\r\n?/g, '\n').trim()
-      if (text && !seen.has(text)) {
-        seen.add(text)
-        texts.push(text)
-      }
+      const text = fs.readFileSync(licensePath, 'utf8')
+        .replace(/\r\n?/g, '\n')
+        .split('\n')
+        .map((line) => line.trimEnd())
+        .join('\n')
+        .trim()
+      if (text) seen.add(text)
     }
   }
-  return texts
+  return [...seen].sort(compareText)
 }
 
-function renderNotices(inventory) {
+function renderNotices(inventory, installedPackageIndex) {
   const entries = Object.entries(inventory)
     .flatMap(([license, packages]) => packages.map((entry) => ({ ...entry, license })))
-    .sort((left, right) => left.name.localeCompare(right.name) || left.versions.join(',').localeCompare(right.versions.join(',')))
+    .sort((left, right) => compareText(left.name, right.name) || compareText(left.versions.join(','), right.versions.join(',')))
 
   const licenseTexts = []
   const textIndexes = new Map()
@@ -68,7 +136,7 @@ function renderNotices(inventory) {
     if (entry.homepage) {
       lines.push(`Homepage: ${entry.homepage}`)
     }
-    const texts = readLicenseTexts(entry)
+    const texts = readLicenseTexts(entry, installedPackageIndex)
     if (texts.length === 0) {
       lines.push('License text: not present in the installed package')
     } else {
@@ -123,11 +191,33 @@ function renderNotices(inventory) {
   ].join('\n')
 }
 
-const rendered = renderNotices(loadLicenseInventory())
+function firstDifference(current, rendered) {
+  const currentLines = current.split('\n')
+  const renderedLines = rendered.split('\n')
+  const lineCount = Math.max(currentLines.length, renderedLines.length)
+  for (let index = 0; index < lineCount; index += 1) {
+    if (currentLines[index] !== renderedLines[index]) {
+      return {
+        line: index + 1,
+        current: currentLines[index] ?? '<end of file>',
+        rendered: renderedLines[index] ?? '<end of file>',
+      }
+    }
+  }
+  return null
+}
+
+const rendered = renderNotices(loadLicenseInventory(), buildInstalledPackageIndex())
 if (process.argv.includes('--check')) {
   const current = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : ''
   if (current !== rendered) {
     console.error('[third-party-notices] docs/legal/THIRD_PARTY_NOTICES.txt is stale; run pnpm notices:generate')
+    const difference = firstDifference(current, rendered)
+    if (difference) {
+      console.error(`[third-party-notices] first difference at line ${difference.line}`)
+      console.error(`[third-party-notices] current: ${JSON.stringify(difference.current)}`)
+      console.error(`[third-party-notices] generated: ${JSON.stringify(difference.rendered)}`)
+    }
     process.exit(1)
   }
   console.log('[third-party-notices] docs/legal/THIRD_PARTY_NOTICES.txt is current')

--- a/src/components/KitionLogoMark.tsx
+++ b/src/components/KitionLogoMark.tsx
@@ -1,0 +1,22 @@
+import type { ImgHTMLAttributes } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export const KITION_LOGO_MARK_URL = `${import.meta.env.BASE_URL}logo-mark.png`
+
+export function KitionLogoMark({
+  alt = 'Kition',
+  className,
+  draggable = false,
+  ...props
+}: ImgHTMLAttributes<HTMLImageElement>) {
+  return (
+    <img
+      {...props}
+      src={KITION_LOGO_MARK_URL}
+      alt={alt}
+      className={cn('shrink-0', className)}
+      draggable={draggable}
+    />
+  )
+}

--- a/src/features/account/components/KitionAccountPanel.spec.tsx
+++ b/src/features/account/components/KitionAccountPanel.spec.tsx
@@ -68,6 +68,7 @@ describe('KitionAccountPanel', () => {
     expect(container.textContent).toContain('Use Kition Cloud models')
     expect(container.textContent).toContain('No separate API key required')
     expect(container.querySelector('[data-testid="portal-account-button"]')).not.toBeNull()
+    expect(container.querySelector('.kition-account-panel__icon img')?.getAttribute('src')).toContain('logo-mark.png')
   })
 
   it.each([

--- a/src/features/account/components/KitionAccountPanel.tsx
+++ b/src/features/account/components/KitionAccountPanel.tsx
@@ -7,11 +7,11 @@ import {
   LoaderCircle,
   LogOut,
   ShieldCheck,
-  UserRound,
   WalletCards,
 } from 'lucide-react'
 
 import { CreditUsageBadge } from '@/components/CreditUsageBadge'
+import { KitionLogoMark } from '@/components/KitionLogoMark'
 import { Button } from '@/components/ui'
 import { useKitionAccount } from '@/features/account/hooks/useKitionAccount'
 import { getKitionAccountLinks } from '@/features/account/lib/accountLinks'
@@ -130,7 +130,7 @@ export function KitionAccountPanel() {
     >
       <header className="kition-account-panel__header">
         <div className="kition-account-panel__icon" aria-hidden="true">
-          {busy ? <LoaderCircle className="size-5 animate-spin" /> : connected ? <UserRound className="size-5" /> : <ShieldCheck className="size-5" />}
+          {busy ? <LoaderCircle className="size-5 animate-spin" /> : <KitionLogoMark alt="" className="size-5" />}
         </div>
         <div className="min-w-0">
           <p className="kition-account-panel__eyebrow">{t('account.eyebrow')}</p>

--- a/src/features/agent/components/AgentChatPanel.tsx
+++ b/src/features/agent/components/AgentChatPanel.tsx
@@ -31,6 +31,7 @@ import type {
   AgentTablePlanContext,
   AgentToolCall,
 } from '@/api/agent'
+import { KitionLogoMark } from '@/components/KitionLogoMark'
 import { Textarea } from '@/components/ui'
 import { AgentModelPicker } from '@/features/agent/components/AgentModelPicker'
 import {
@@ -193,7 +194,7 @@ export function AgentChatPanel({
           // them toward an unblocked state.
           return (
           <AgentPanelEmptyState
-            icon={<img src="/logo-mark.png" alt="Kition" className="size-5 shrink-0" />}
+            icon={<KitionLogoMark className="size-5" />}
             title="Kition"
             description={emptyState.description}
             actions={needsModelConfig ? (

--- a/src/features/settings/DesktopSettingsPage.spec.tsx
+++ b/src/features/settings/DesktopSettingsPage.spec.tsx
@@ -90,6 +90,9 @@ describe('DesktopSettingsPage information architecture', () => {
     expect(container.textContent).not.toContain('Hooks')
     expect(container.textContent).not.toContain('Notifications')
     expect(container.querySelectorAll('.settings-nav-button.is-active')).toHaveLength(1)
+    for (const button of container.querySelectorAll<HTMLButtonElement>('.settings-nav-button')) {
+      expect(button.type).toBe('button')
+    }
 
     clickButton('Advanced')
     expect(container.textContent).toContain('Network')

--- a/src/features/settings/DesktopSettingsPage.tsx
+++ b/src/features/settings/DesktopSettingsPage.tsx
@@ -1270,8 +1270,12 @@ export function DesktopSettingsPage({ initialSection, onClose }: DesktopSettings
     return (
       <button
         key={section.key}
+        type="button"
         className={cn('settings-nav-button', child && 'is-child', active && 'is-active')}
-        onClick={() => switchSection(section.key)}
+        onClick={(event) => {
+          event.stopPropagation()
+          switchSection(section.key)
+        }}
         aria-current={active ? 'page' : undefined}
       >
         <SectionIcon className="size-4" />

--- a/src/features/table/grid/components/editor/TextEditor.spec.tsx
+++ b/src/features/table/grid/components/editor/TextEditor.spec.tsx
@@ -51,6 +51,12 @@ describe('TextEditor focus treatment', () => {
   })
 
   it('uses the compact table date editor instead of the native datetime picker', async () => {
+    const value = '2026-07-23T04:14:47Z'
+    const localDate = new Date(value)
+    const pad = (part: number) => String(part).padStart(2, '0')
+    const expectedDate = `${localDate.getFullYear()}-${pad(localDate.getMonth() + 1)}-${pad(localDate.getDate())}`
+    const expectedTime = `${pad(localDate.getHours())}:${pad(localDate.getMinutes())}`
+
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -60,7 +66,7 @@ describe('TextEditor focus treatment', () => {
         createElement(TextEditor, {
           cell: {
             type: CellType.Text,
-            data: '2026-07-23T04:14:47Z',
+            data: value,
             displayData: '2026/07/23 12:14',
             inputType: 'datetime-local',
           } as ITextCell,
@@ -74,8 +80,8 @@ describe('TextEditor focus treatment', () => {
 
     const editor = container.querySelector('[data-testid="table-date-cell-editor"]')
     expect(editor).not.toBeNull()
-    expect(editor?.textContent).toContain('2026-07-23')
-    expect(editor?.textContent).toContain('12:14')
+    expect(editor?.textContent).toContain(expectedDate)
+    expect(editor?.textContent).toContain(expectedTime)
     expect(container.querySelector('input[type="datetime-local"]')).toBeNull()
     expect(document.querySelector('[data-testid="table-date-calendar"]')).not.toBeNull()
   })

--- a/src/features/workspace/components/WorkspaceLauncherScreen.tsx
+++ b/src/features/workspace/components/WorkspaceLauncherScreen.tsx
@@ -6,6 +6,7 @@ import {
   X,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { KitionLogoMark } from '@/components/KitionLogoMark'
 import { Button, Card, CardContent, Input } from '@/components/ui'
 import { useConfirm } from '@/components/confirm'
 import { useDismissableLayer } from '@/registry/hooks/use-on-click-outside'
@@ -218,7 +219,7 @@ export function WorkspaceLauncherScreen({
 
         <section className="flex flex-1 flex-col items-center justify-center bg-background px-12 py-10 text-foreground">
           <div className="flex flex-col items-center pb-8 text-center">
-            <img src="/logo-mark.png" alt="Kition" className="size-20" draggable={false} />
+            <KitionLogoMark className="size-20" />
             <h1 className="mt-4 text-3xl font-semibold text-foreground">Kition</h1>
             {appVersion ? (
               <p className="mt-1 text-xs text-muted-foreground">{t('subtitle', { version: appVersion })}</p>

--- a/tooling/vite.config.ts
+++ b/tooling/vite.config.ts
@@ -55,6 +55,12 @@ export default defineConfig(({ mode }) => ({
       '@': resolve(repositoryDir, 'src'),
     },
   },
+  optimizeDeps: {
+    // Search runs in a worker and starts on idle, so Vite's cold-start scanner
+    // cannot discover these dependencies from index.html. Pre-bundle them to
+    // prevent a full-page reload when the worker starts during renderer E2E.
+    include: ['@orama/orama', 'idb'],
+  },
   css: {
     postcss: resolve(repositoryDir, 'tooling'),
   },


### PR DESCRIPTION
## Summary

- resolve the Kition logo from Vite's renderer base path so it works over `file://`
- use the shared production-safe logo in Agent, workspace launcher, and account surfaces
- reject root-relative logo references during desktop renderer validation
- pre-optimize worker-only search dependencies so a cold Vite start cannot reload and close settings during renderer E2E
- generate deterministic third-party notices from exact installed package versions across platforms
- make the date editor test timezone-independent

## Validation

- `pnpm run build:check`
- desktop production build with `KITION_DESKTOP_BUILD=true`
- `node electron/scripts/validate-desktop-renderer.mjs`
- 37 targeted logo and renderer validation tests
- settings unit tests (5 passed)
- date editor test under `TZ=UTC` and `TZ=Asia/Shanghai`
- cold-cache app-shell navigation E2E (1 passed)
- `python3 scripts/check-i18n.py`
- `python3 scripts/check-branding.py`
- `python3 scripts/check-product-language.py`
- `python3 scripts/check-secrets.py`
- `pnpm test:table:e2e` (13 passed)