### PR TITLE
Fix Agent chat responsiveness and document context

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -3618,18 +3618,72 @@
     @apply max-w-full truncate text-xs text-muted-foreground;
   }
 
-  .agent-mention-chip-row {
-    @apply mt-2 flex flex-wrap gap-2;
+  .agent-document-references {
+    @apply mt-2 max-w-full;
   }
 
-  .agent-mention-chip,
-  .agent-inline-mention {
-    @apply inline-flex items-center gap-1 rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-xs font-medium text-sky-800;
+  .agent-document-reference {
+    @apply flex h-8 w-fit max-w-full items-center overflow-hidden rounded-md border bg-secondary text-xs text-foreground;
+    border-color: var(--document-border, hsl(var(--border)));
   }
 
-  .agent-inline-mention--button,
-  .agent-inline-mention[type='button'] {
-    @apply cursor-pointer transition-colors hover:bg-sky-100;
+  .agent-document-reference__main {
+    @apply flex min-w-0 max-w-full items-center gap-1.5 px-2.5 text-left;
+  }
+
+  button.agent-document-reference__main {
+    @apply h-full transition-colors hover:bg-muted;
+  }
+
+  .agent-document-reference__name {
+    @apply min-w-0 truncate font-medium;
+  }
+
+  .agent-document-reference__remove {
+    @apply inline-grid h-full w-8 shrink-0 place-items-center border-l text-muted-foreground transition-colors hover:bg-muted hover:text-foreground;
+    border-left-color: var(--document-border, hsl(var(--border)));
+  }
+
+  .agent-document-references--select {
+    @apply relative w-full;
+  }
+
+  .agent-document-references--select > summary {
+    @apply flex h-8 w-full cursor-pointer list-none items-center gap-1.5 rounded-md border bg-secondary px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted;
+    border-color: var(--document-border, hsl(var(--border)));
+  }
+
+  .agent-document-references--select > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .agent-document-references__chevron {
+    @apply ml-auto text-muted-foreground transition-transform;
+  }
+
+  .agent-document-references--select[open] .agent-document-references__chevron {
+    transform: rotate(180deg);
+  }
+
+  .agent-document-references__menu {
+    @apply absolute bottom-[calc(100%+0.375rem)] left-0 z-30 grid w-full gap-1 rounded-lg border bg-popover p-1 shadow-floating;
+    border-color: var(--document-border, hsl(var(--border)));
+  }
+
+  .agent-document-references__menu .agent-document-reference {
+    @apply w-full border-0 bg-transparent;
+  }
+
+  .agent-document-references__menu .agent-document-reference__main {
+    @apply flex-1;
+  }
+
+  .agent-document-references--message {
+    @apply max-w-full;
+  }
+
+  .agent-document-references--message .agent-document-references__menu {
+    @apply bottom-auto top-[calc(100%+0.375rem)];
   }
 
   .agent-inline-path {

--- a/src/features/agent/components/AgentAiComposer.tsx
+++ b/src/features/agent/components/AgentAiComposer.tsx
@@ -1,0 +1,316 @@
+import { ArrowUp, FileText, Folder, Globe, X } from 'lucide-react'
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Textarea } from '@/components/ui'
+import { AgentDocumentReferences } from '@/features/agent/components/AgentDocumentReferences'
+import { AgentModelPicker } from '@/features/agent/components/AgentModelPicker'
+import type { KitionAccountStatus } from '@/features/account/hooks/useKitionAccount'
+import type { AgentModelOption } from '@/features/agent/lib/agentConfig'
+import {
+  buildAgentDraftWithDocumentMentions,
+  findAgentMentionQuery,
+  getUniqueAgentDocumentMentionPaths,
+  removeAgentDocumentMention,
+  stripAgentDocumentMentions,
+  type AgentMentionableDocument,
+} from '@/features/agent/lib/documentMentions'
+import { WEB_BROWSER_ENABLED } from '@/lib/productFeatures'
+import { cn } from '@/lib/utils'
+
+type AgentAiComposerProps = {
+  busy: boolean
+  canSend: boolean
+  compact?: boolean
+  draft: string
+  mentionableDocuments: AgentMentionableDocument[]
+  modelOptions: AgentModelOption[]
+  needsModelConfig: boolean
+  hostedAccountStatus?: KitionAccountStatus
+  selectedModelKey: string
+  browserEnabled: boolean
+  onConfigureModel: () => void
+  onHostedAccountConnect?: () => void
+  onHostedAccountCancel?: () => void
+  onHostedAccountBilling?: () => void
+  onDraftChange: (value: string) => void
+  onImportFiles?: (files: File[]) => Promise<string[]>
+  onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void
+  onModelChange: (value: string) => void
+  onSend: () => void
+  onStop: () => void
+  onBrowserEnabledChange: (next: boolean) => void
+}
+
+export function AgentAiComposer({
+  busy,
+  canSend,
+  compact = false,
+  draft,
+  mentionableDocuments,
+  modelOptions,
+  needsModelConfig,
+  hostedAccountStatus,
+  selectedModelKey,
+  browserEnabled,
+  onConfigureModel,
+  onHostedAccountConnect,
+  onHostedAccountCancel,
+  onHostedAccountBilling,
+  onDraftChange,
+  onImportFiles,
+  onKeyDown,
+  onModelChange,
+  onSend,
+  onStop,
+  onBrowserEnabledChange,
+}: AgentAiComposerProps) {
+  const { t } = useTranslation('agent')
+  const [highlightedMentionIndex, setHighlightedMentionIndex] = useState(0)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const visibleDraft = stripAgentDocumentMentions(draft)
+  const referencedPaths = getUniqueAgentDocumentMentionPaths(draft)
+  const documentsByPath = new Map(
+    mentionableDocuments.map((document) => [document.path, document]),
+  )
+  const references = referencedPaths.map((path) => ({
+    path,
+    kind: documentsByPath.get(path)?.kind,
+  }))
+
+  useEffect(() => {
+    function handle() {
+      requestAnimationFrame(() => {
+        const el = textareaRef.current
+        if (!el) return
+        el.focus()
+        const end = el.value.length
+        el.setSelectionRange(end, end)
+      })
+    }
+    window.addEventListener('kition:agent:focus-composer', handle)
+    return () => {
+      window.removeEventListener('kition:agent:focus-composer', handle)
+    }
+  }, [])
+
+  const mentionQuery = findAgentMentionQuery(
+    visibleDraft,
+    textareaRef.current?.selectionStart ?? visibleDraft.length,
+  )
+  const filteredMentions = mentionQuery
+    ? mentionableDocuments
+        .filter((document) => {
+          const keyword = `${document.title} ${document.name} ${document.path}`.toLowerCase()
+          return keyword.includes(mentionQuery.query.trim().toLowerCase())
+        })
+        .slice(0, 8)
+    : []
+
+  useEffect(() => {
+    setHighlightedMentionIndex(0)
+  }, [mentionQuery?.query])
+
+  function updateVisibleDraft(nextVisibleDraft: string) {
+    onDraftChange(
+      buildAgentDraftWithDocumentMentions(nextVisibleDraft, referencedPaths),
+    )
+  }
+
+  function selectMention(document: AgentMentionableDocument) {
+    if (!mentionQuery) {
+      return
+    }
+    const head = visibleDraft.slice(0, mentionQuery.start)
+    const rawTail = visibleDraft.slice(mentionQuery.end)
+    const tail = /\s$/.test(head) && /^\s/.test(rawTail)
+      ? rawTail.replace(/^\s+/, '')
+      : rawTail
+    const nextVisibleDraft = `${head}${tail}`
+    onDraftChange(buildAgentDraftWithDocumentMentions(
+      nextVisibleDraft,
+      [...referencedPaths, document.path],
+    ))
+    window.requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+      textareaRef.current?.setSelectionRange(head.length, head.length)
+    })
+  }
+
+  async function handleImportedFiles(files: File[]) {
+    if (!onImportFiles || !files.length) {
+      return
+    }
+    const importedPaths = await onImportFiles(files)
+    if (!importedPaths.length) {
+      return
+    }
+    onDraftChange(buildAgentDraftWithDocumentMentions(
+      visibleDraft,
+      [...referencedPaths, ...importedPaths],
+    ))
+    window.requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+    })
+  }
+
+  return (
+    <div className={cn('agent-ai-composer', compact && 'is-compact')}>
+      <Textarea
+        ref={textareaRef}
+        value={visibleDraft}
+        onChange={(event) => updateVisibleDraft(event.target.value)}
+        onDragOver={onImportFiles ? (event) => {
+          if (event.dataTransfer?.types?.includes('Files')) {
+            event.preventDefault()
+            event.dataTransfer.dropEffect = 'copy'
+          }
+        } : undefined}
+        onDrop={onImportFiles ? (event) => {
+          const files = Array.from(event.dataTransfer?.files || [])
+          if (!files.length) {
+            return
+          }
+          event.preventDefault()
+          void handleImportedFiles(files)
+        } : undefined}
+        onPaste={onImportFiles ? (event) => {
+          const files = Array.from(event.clipboardData?.files || [])
+          if (!files.length) {
+            return
+          }
+          event.preventDefault()
+          void handleImportedFiles(files)
+        } : undefined}
+        onKeyDown={(event) => {
+          if (mentionQuery && filteredMentions.length) {
+            if (event.key === 'ArrowDown') {
+              event.preventDefault()
+              setHighlightedMentionIndex((current) =>
+                Math.min(filteredMentions.length - 1, current + 1),
+              )
+              return
+            }
+            if (event.key === 'ArrowUp') {
+              event.preventDefault()
+              setHighlightedMentionIndex((current) => Math.max(0, current - 1))
+              return
+            }
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault()
+              const selectedMention =
+                filteredMentions[highlightedMentionIndex] || filteredMentions[0]
+              if (selectedMention) {
+                selectMention(selectedMention)
+              }
+              return
+            }
+          }
+          onKeyDown(event)
+        }}
+        placeholder="Plan, write, or ask anything…"
+        disabled={busy}
+      />
+      {mentionQuery && filteredMentions.length ? (
+        <div className="agent-mention-menu">
+          {filteredMentions.map((document, index) => (
+            <button
+              key={document.path}
+              type="button"
+              className={cn(
+                'agent-mention-menu__item',
+                index === highlightedMentionIndex && 'is-active',
+              )}
+              onMouseDown={(event) => {
+                event.preventDefault()
+                selectMention(document)
+              }}
+            >
+              {document.kind === 'folder' ? (
+                <Folder className="agent-mention-menu__icon size-4 shrink-0" />
+              ) : (
+                <FileText className="agent-mention-menu__icon size-4 shrink-0" />
+              )}
+              <span className="agent-mention-menu__text">
+                <strong>{document.title}</strong>
+                <span>{document.path}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <AgentDocumentReferences
+        references={references}
+        onRemove={(path) => onDraftChange(removeAgentDocumentMention(draft, path))}
+      />
+      <div className="agent-ai-footer">
+        <AgentModelPicker
+          className="agent-ai-model-picker"
+          variant="compact"
+          menuPlacement="top"
+          value={selectedModelKey}
+          options={modelOptions}
+          onChange={onModelChange}
+          disabled={busy || !modelOptions.length}
+        />
+        {WEB_BROWSER_ENABLED ? (
+          <button
+            type="button"
+            className={cn('agent-ai-browser-toggle', browserEnabled && 'is-active')}
+            aria-pressed={browserEnabled}
+            disabled={busy}
+            title={
+              browserEnabled
+                ? 'Browser search enabled: model can call browser_search in the embedded browser'
+                : 'Browser search disabled: model uses AI-native web_search'
+            }
+            onClick={() => onBrowserEnabledChange(!browserEnabled)}
+          >
+            <Globe className="size-3.5" />
+            <span>Browser</span>
+          </button>
+        ) : null}
+        {needsModelConfig ? (
+          <button type="button" className="agent-ai-configure" onClick={onConfigureModel}>
+            Configure
+          </button>
+        ) : hostedAccountStatus && hostedAccountStatus !== 'ready' ? (
+          <button
+            type="button"
+            className="agent-ai-configure"
+            onClick={hostedAccountStatus === 'credits_empty'
+              ? onHostedAccountBilling
+              : hostedAccountStatus === 'connecting'
+                ? onHostedAccountCancel
+                : onHostedAccountConnect}
+            disabled={hostedAccountStatus === 'loading'}
+            data-testid="agent-composer-kition-account"
+          >
+            {hostedAccountStatus === 'credits_empty'
+              ? t('emptyState.kitionAccount.topUp')
+              : hostedAccountStatus === 'loading'
+              ? t('emptyState.kitionAccount.checking')
+              : hostedAccountStatus === 'connecting'
+                ? t('emptyState.kitionAccount.cancel')
+                : hostedAccountStatus === 'temporary_error'
+                  ? t('emptyState.kitionAccount.retry')
+                  : hostedAccountStatus === 'expired'
+                    ? t('emptyState.kitionAccount.signInAgain')
+                    : t('emptyState.kitionAccount.signIn')}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="agent-ai-send"
+          aria-label={busy ? 'Stop' : 'Send'}
+          title={busy ? 'Stop' : 'Send'}
+          onClick={busy ? onStop : onSend}
+          disabled={busy ? false : (!canSend || needsModelConfig)}
+        >
+          {busy ? <X className="size-4" /> : <ArrowUp className="size-4" />}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/agent/components/AgentChatPanel.spec.tsx
+++ b/src/features/agent/components/AgentChatPanel.spec.tsx
@@ -375,3 +375,76 @@ describe('AgentChatPanel Kition Account readiness', () => {
     expect((container.querySelector('[aria-label="Send"]') as HTMLButtonElement).disabled).toBe(true)
   })
 })
+
+describe('AgentChatPanel document references', () => {
+  beforeEach(async () => {
+    await unmount()
+  })
+
+  const longPath = 'Getting Started/Guides/Product Content/Product Content Studio.kitable'
+
+  it('hides mention tokens and shows only the removable file name', async () => {
+    const onDraftChange = vi.fn()
+    await mount(createElement(AgentChatPanel, makeMinimalProps({
+      draft: `Analyze this document\n@{${longPath}}`,
+      mentionableDocuments: [{
+        kind: 'file',
+        path: longPath,
+        name: 'Product Content Studio.kitable',
+        title: 'Product Content Studio',
+        format: 'data',
+      }],
+      onDraftChange,
+    })))
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea.value).toBe('Analyze this document')
+    expect(container.textContent).toContain('Product Content Studio.kitable')
+    expect(container.textContent).not.toContain('@{')
+    expect(container.textContent).not.toContain('Getting Started/Guides')
+
+    const remove = container.querySelector(
+      '[aria-label="Remove Product Content Studio.kitable"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      remove.click()
+    })
+    expect(onDraftChange).toHaveBeenCalledWith('Analyze this document')
+  })
+
+  it('collapses multiple references into a select-style control', async () => {
+    await mount(createElement(AgentChatPanel, makeMinimalProps({
+      draft: 'Compare these\n@{Docs/Plan.md} @{Notes/Todo.md}',
+      mentionableDocuments: [
+        { kind: 'file', path: 'Docs/Plan.md', name: 'Plan.md', title: 'Plan', format: 'markdown' },
+        { kind: 'file', path: 'Notes/Todo.md', name: 'Todo.md', title: 'Todo', format: 'markdown' },
+      ],
+    })))
+
+    const select = container.querySelector(
+      '[data-testid="agent-document-reference-select"]',
+    ) as HTMLElement
+    expect(select).not.toBeNull()
+    expect(select.textContent).toContain('2 files')
+  })
+
+  it('renders sent messages without raw mention syntax or folder paths', async () => {
+    await mount(createElement(AgentChatPanel, makeMinimalProps({
+      messages: [{
+        id: 41,
+        session_id: 1,
+        user_id: 1,
+        role: 'user',
+        content: `Summarize it\n@{${longPath}}`,
+        status: 'completed',
+        created_at: new Date().toISOString(),
+      }],
+    })))
+
+    const userMessage = container.querySelector('[data-role="user"]') as HTMLElement
+    expect(userMessage.textContent).toContain('Summarize it')
+    expect(userMessage.textContent).toContain('Product Content Studio.kitable')
+    expect(userMessage.textContent).not.toContain('@{')
+    expect(userMessage.textContent).not.toContain('Getting Started/Guides')
+  })
+})

--- a/src/features/agent/components/AgentChatPanel.tsx
+++ b/src/features/agent/components/AgentChatPanel.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowUp,
   Check,
   ChevronDown,
   ChevronRight,
@@ -9,8 +8,6 @@ import {
   FileText,
   FileType2,
   FileVideo2,
-  Folder,
-  Globe,
   LoaderCircle,
   Presentation,
   Sparkles,
@@ -32,8 +29,8 @@ import type {
   AgentToolCall,
 } from '@/api/agent'
 import { KitionLogoMark } from '@/components/KitionLogoMark'
-import { Textarea } from '@/components/ui'
-import { AgentModelPicker } from '@/features/agent/components/AgentModelPicker'
+import { AgentAiComposer } from '@/features/agent/components/AgentAiComposer'
+import { AgentDocumentReferences } from '@/features/agent/components/AgentDocumentReferences'
 import {
   AgentContextCards,
 } from '@/features/agent/components/AgentContextCards'
@@ -46,9 +43,8 @@ import type { KitionAccountStatus } from '@/features/account/hooks/useKitionAcco
 import { isKitionAccountUsable } from '@/features/account/lib/accountState'
 import type { AgentMentionableDocument } from '@/features/agent/lib/documentMentions'
 import {
-  applyAgentMentionSelection,
-  findAgentMentionQuery,
-  parseAgentMentionSegments,
+  getUniqueAgentDocumentMentionPaths,
+  stripAgentDocumentMentions,
 } from '@/features/agent/lib/documentMentions'
 import {
   type AgentPaneContext,
@@ -59,7 +55,6 @@ import { resolveAgentImageURL } from '@/services/workspaceFiles'
 import {
   type AgentModelOption,
 } from '@/features/agent/lib/agentConfig'
-import { WEB_BROWSER_ENABLED } from '@/lib/productFeatures'
 import { PlanCard, readLatestPlanSnapshot } from '@/features/agent/components/PlanCard'
 import {
   AwaitUserInputModal,
@@ -301,311 +296,6 @@ export function AgentChatPanel({
           onStop={onStop}
           onBrowserEnabledChange={onBrowserEnabledChange}
         />
-      </div>
-    </div>
-  )
-}
-
-function AgentAiComposer({
-  busy,
-  canSend,
-  compact = false,
-  draft,
-  mentionableDocuments,
-  modelOptions,
-  needsModelConfig,
-  hostedAccountStatus,
-  selectedModelKey,
-  browserEnabled,
-  onConfigureModel,
-  onHostedAccountConnect,
-  onHostedAccountCancel,
-  onHostedAccountBilling,
-  onDraftChange,
-  onImportFiles,
-  onKeyDown,
-  onModelChange,
-  onSend,
-  onStop,
-  onBrowserEnabledChange,
-}: {
-  busy: boolean
-  canSend: boolean
-  compact?: boolean
-  draft: string
-  mentionableDocuments: AgentMentionableDocument[]
-  modelOptions: AgentModelOption[]
-  needsModelConfig: boolean
-  hostedAccountStatus?: KitionAccountStatus
-  selectedModelKey: string
-  browserEnabled: boolean
-  onConfigureModel: () => void
-  onHostedAccountConnect?: () => void
-  onHostedAccountCancel?: () => void
-  onHostedAccountBilling?: () => void
-  onDraftChange: (value: string) => void
-  onImportFiles?: (files: File[]) => Promise<string[]>
-  onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void
-  onModelChange: (value: string) => void
-  onSend: () => void
-  onStop: () => void
-  onBrowserEnabledChange: (next: boolean) => void
-}) {
-  const { t } = useTranslation('agent')
-  const [highlightedMentionIndex, setHighlightedMentionIndex] = useState(0)
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
-
-  useEffect(() => {
-    function handle() {
-      requestAnimationFrame(() => {
-        const el = textareaRef.current
-        if (!el) return
-        el.focus()
-        const end = el.value.length
-        el.setSelectionRange(end, end)
-      })
-    }
-    window.addEventListener('kition:agent:focus-composer', handle)
-    return () => {
-      window.removeEventListener('kition:agent:focus-composer', handle)
-    }
-  }, [])
-
-  const mentionQuery = findAgentMentionQuery(
-    draft,
-    textareaRef.current?.selectionStart ?? draft.length,
-  )
-  const filteredMentions = mentionQuery
-    ? mentionableDocuments
-        .filter((document) => {
-          const keyword = `${document.title} ${document.name} ${document.path}`.toLowerCase()
-          return keyword.includes(mentionQuery.query.trim().toLowerCase())
-        })
-        .slice(0, 8)
-    : []
-  const mentionedDocuments = parseAgentMentionSegments(draft)
-    .filter((segment) => segment.type === 'mention')
-    .map((segment) => segment.path)
-  const mentionKindByPath = new Map(
-    mentionableDocuments.map((document) => [document.path, document.kind]),
-  )
-
-  useEffect(() => {
-    setHighlightedMentionIndex(0)
-  }, [mentionQuery?.query])
-
-  async function handleImportedFiles(files: File[]) {
-    if (!onImportFiles || !files.length) {
-      return
-    }
-    const importedPaths = await onImportFiles(files)
-    if (!importedPaths.length) {
-      return
-    }
-    const textarea = textareaRef.current
-    const insertionPoint = textarea?.selectionStart ?? draft.length
-    const head = draft.slice(0, insertionPoint)
-    const tail = draft.slice(insertionPoint)
-    const mentionTokens = importedPaths.map((path) => `@{${path}}`).join(' ')
-    const prefixSeparator = head && !head.endsWith(' ') && !head.endsWith('\n') ? ' ' : ''
-    const suffixSeparator = tail.startsWith(' ') || tail.startsWith('\n') ? '' : ' '
-    const insertion = `${prefixSeparator}${mentionTokens}${suffixSeparator}`
-    const nextContent = `${head}${insertion}${tail}`
-    onDraftChange(nextContent)
-    const nextCaret = head.length + insertion.length
-    window.requestAnimationFrame(() => {
-      textareaRef.current?.focus()
-      textareaRef.current?.setSelectionRange(nextCaret, nextCaret)
-    })
-  }
-
-  return (
-    <div className={cn('agent-ai-composer', compact && 'is-compact')}>
-      <Textarea
-        ref={textareaRef}
-        value={draft}
-        onChange={(event) => onDraftChange(event.target.value)}
-        onDragOver={onImportFiles ? (event) => {
-          if (event.dataTransfer?.types?.includes('Files')) {
-            event.preventDefault()
-            event.dataTransfer.dropEffect = 'copy'
-          }
-        } : undefined}
-        onDrop={onImportFiles ? (event) => {
-          const files = Array.from(event.dataTransfer?.files || [])
-          if (!files.length) {
-            return
-          }
-          event.preventDefault()
-          void handleImportedFiles(files)
-        } : undefined}
-        onPaste={onImportFiles ? (event) => {
-          const files = Array.from(event.clipboardData?.files || [])
-          if (!files.length) {
-            return
-          }
-          event.preventDefault()
-          void handleImportedFiles(files)
-        } : undefined}
-        onKeyDown={(event) => {
-          if (mentionQuery && filteredMentions.length) {
-            if (event.key === 'ArrowDown') {
-              event.preventDefault()
-              setHighlightedMentionIndex((current) =>
-                Math.min(filteredMentions.length - 1, current + 1),
-              )
-              return
-            }
-            if (event.key === 'ArrowUp') {
-              event.preventDefault()
-              setHighlightedMentionIndex((current) => Math.max(0, current - 1))
-              return
-            }
-            if (event.key === 'Enter' && !event.shiftKey) {
-              event.preventDefault()
-              const selectedMention =
-                filteredMentions[highlightedMentionIndex] || filteredMentions[0]
-              if (selectedMention) {
-                const next = applyAgentMentionSelection({
-                  content: draft,
-                  mention: mentionQuery,
-                  path: selectedMention.path,
-                })
-                onDraftChange(next.content)
-                window.requestAnimationFrame(() => {
-                  textareaRef.current?.focus()
-                  textareaRef.current?.setSelectionRange(next.caret, next.caret)
-                })
-              }
-              return
-            }
-          }
-          onKeyDown(event)
-        }}
-        placeholder="Plan, write, or ask anything…"
-        disabled={busy}
-      />
-      {mentionQuery && filteredMentions.length ? (
-        <div className="agent-mention-menu">
-          {filteredMentions.map((document, index) => (
-            <button
-              key={document.path}
-              type="button"
-              className={cn(
-                'agent-mention-menu__item',
-                index === highlightedMentionIndex && 'is-active',
-              )}
-              onMouseDown={(event) => {
-                event.preventDefault()
-                const next = applyAgentMentionSelection({
-                  content: draft,
-                  mention: mentionQuery,
-                  path: document.path,
-                })
-                onDraftChange(next.content)
-                window.requestAnimationFrame(() => {
-                  textareaRef.current?.focus()
-                  textareaRef.current?.setSelectionRange(next.caret, next.caret)
-                })
-              }}
-            >
-              {document.kind === 'folder' ? (
-                <Folder className="agent-mention-menu__icon size-4 shrink-0" />
-              ) : (
-                <FileText className="agent-mention-menu__icon size-4 shrink-0" />
-              )}
-              <span className="agent-mention-menu__text">
-                <strong>{document.title}</strong>
-                <span>{document.path}</span>
-              </span>
-            </button>
-          ))}
-        </div>
-      ) : null}
-      {mentionedDocuments.length ? (
-        <div className="agent-mention-chip-row">
-          {mentionedDocuments.map((path) => (
-            <span
-              key={path}
-              className="agent-mention-chip max-w-full min-w-0"
-              title={path}
-            >
-              {mentionKindByPath.get(path) === 'folder' ? (
-                <Folder className="size-3.5 shrink-0" />
-              ) : (
-                <FileText className="size-3.5 shrink-0" />
-              )}
-              <span className="min-w-0 truncate">{path}</span>
-            </span>
-          ))}
-        </div>
-      ) : null}
-      <div className="agent-ai-footer">
-        <AgentModelPicker
-          className="agent-ai-model-picker"
-          variant="compact"
-          menuPlacement="top"
-          value={selectedModelKey}
-          options={modelOptions}
-          onChange={onModelChange}
-          disabled={busy || !modelOptions.length}
-        />
-        {WEB_BROWSER_ENABLED ? (
-          <button
-            type="button"
-            className={cn('agent-ai-browser-toggle', browserEnabled && 'is-active')}
-            aria-pressed={browserEnabled}
-            disabled={busy}
-            title={
-              browserEnabled
-                ? 'Browser search enabled: model can call browser_search in the embedded browser'
-                : 'Browser search disabled: model uses AI-native web_search'
-            }
-            onClick={() => onBrowserEnabledChange(!browserEnabled)}
-          >
-            <Globe className="size-3.5" />
-            <span>Browser</span>
-          </button>
-        ) : null}
-        {needsModelConfig ? (
-          <button type="button" className="agent-ai-configure" onClick={onConfigureModel}>
-            Configure
-          </button>
-        ) : hostedAccountStatus && hostedAccountStatus !== 'ready' ? (
-          <button
-            type="button"
-            className="agent-ai-configure"
-            onClick={hostedAccountStatus === 'credits_empty'
-              ? onHostedAccountBilling
-              : hostedAccountStatus === 'connecting'
-                ? onHostedAccountCancel
-                : onHostedAccountConnect}
-            disabled={hostedAccountStatus === 'loading'}
-            data-testid="agent-composer-kition-account"
-          >
-            {hostedAccountStatus === 'credits_empty'
-              ? t('emptyState.kitionAccount.topUp')
-              : hostedAccountStatus === 'loading'
-              ? t('emptyState.kitionAccount.checking')
-              : hostedAccountStatus === 'connecting'
-                ? t('emptyState.kitionAccount.cancel')
-                : hostedAccountStatus === 'temporary_error'
-                  ? t('emptyState.kitionAccount.retry')
-                  : hostedAccountStatus === 'expired'
-                    ? t('emptyState.kitionAccount.signInAgain')
-                  : t('emptyState.kitionAccount.signIn')}
-          </button>
-        ) : null}
-        <button
-          type="button"
-          className="agent-ai-send"
-          aria-label={busy ? 'Stop' : 'Send'}
-          title={busy ? 'Stop' : 'Send'}
-          onClick={busy ? onStop : onSend}
-          disabled={busy ? false : (!canSend || needsModelConfig)}
-        >
-          {busy ? <X className="size-4" /> : <ArrowUp className="size-4" />}
-        </button>
       </div>
     </div>
   )
@@ -876,21 +566,18 @@ function renderAgentUserMessageContent(
   content: string,
   onOpenPath: (path: string) => void,
 ) {
-  return parseAgentMentionSegments(content).map((segment, index) => {
-    if (segment.type === 'text') {
-      return <Fragment key={`text:${index}`}>{segment.value}</Fragment>
-    }
-    return (
-      <button
-        key={`mention:${segment.path}:${index}`}
-        type="button"
-        className="agent-inline-mention agent-inline-mention--button"
-        onClick={() => onOpenPath(segment.path)}
-      >
-        @{segment.path}
-      </button>
-    )
-  })
+  const visibleContent = stripAgentDocumentMentions(content)
+  const references = getUniqueAgentDocumentMentionPaths(content).map((path) => ({ path }))
+  return (
+    <>
+      {visibleContent ? <span>{visibleContent}</span> : null}
+      <AgentDocumentReferences
+        className="agent-document-references--message"
+        references={references}
+        onOpen={onOpenPath}
+      />
+    </>
+  )
 }
 
 function AgentRunLog({

--- a/src/features/agent/components/AgentDocumentReferences.tsx
+++ b/src/features/agent/components/AgentDocumentReferences.tsx
@@ -1,0 +1,115 @@
+import { ChevronDown, FileText, Folder, X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+export type AgentDocumentReference = {
+  path: string
+  kind?: 'file' | 'folder'
+}
+
+type AgentDocumentReferencesProps = {
+  references: AgentDocumentReference[]
+  onOpen?: (path: string) => void
+  onRemove?: (path: string) => void
+  className?: string
+}
+
+function getReferenceName(path: string) {
+  return path.split('/').filter(Boolean).pop() || path
+}
+
+function ReferenceIcon({ kind }: { kind?: 'file' | 'folder' }) {
+  return kind === 'folder'
+    ? <Folder className="size-3.5 shrink-0" />
+    : <FileText className="size-3.5 shrink-0" />
+}
+
+function ReferenceRow({
+  reference,
+  onOpen,
+  onRemove,
+}: {
+  reference: AgentDocumentReference
+  onOpen?: (path: string) => void
+  onRemove?: (path: string) => void
+}) {
+  const name = getReferenceName(reference.path)
+  const content = (
+    <>
+      <ReferenceIcon kind={reference.kind} />
+      <span className="agent-document-reference__name">{name}</span>
+    </>
+  )
+
+  return (
+    <div className="agent-document-reference" title={reference.path}>
+      {onOpen ? (
+        <button
+          type="button"
+          className="agent-document-reference__main"
+          onClick={() => onOpen(reference.path)}
+        >
+          {content}
+        </button>
+      ) : (
+        <span className="agent-document-reference__main">{content}</span>
+      )}
+      {onRemove ? (
+        <button
+          type="button"
+          className="agent-document-reference__remove"
+          aria-label={`Remove ${name}`}
+          title={`Remove ${name}`}
+          onClick={() => onRemove(reference.path)}
+        >
+          <X className="size-3.5" />
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+export function AgentDocumentReferences({
+  references,
+  onOpen,
+  onRemove,
+  className,
+}: AgentDocumentReferencesProps) {
+  if (!references.length) {
+    return null
+  }
+  if (references.length === 1) {
+    return (
+      <div className={cn('agent-document-references', className)}>
+        <ReferenceRow
+          reference={references[0]}
+          onOpen={onOpen}
+          onRemove={onRemove}
+        />
+      </div>
+    )
+  }
+
+  const allFiles = references.every((reference) => reference.kind !== 'folder')
+  return (
+    <details
+      className={cn('agent-document-references agent-document-references--select', className)}
+    >
+      <summary data-testid="agent-document-reference-select">
+        <FileText className="size-3.5 shrink-0" />
+        <span>{references.length} {allFiles ? 'files' : 'references'}</span>
+        <ChevronDown className="agent-document-references__chevron size-3.5 shrink-0" />
+      </summary>
+      <div className="agent-document-references__menu">
+        {references.map((reference) => (
+          <ReferenceRow
+            key={reference.path}
+            reference={reference}
+            onOpen={onOpen}
+            onRemove={onRemove}
+          />
+        ))}
+      </div>
+    </details>
+  )
+}

--- a/src/features/agent/hooks/useWorkspaceAgent.spec.ts
+++ b/src/features/agent/hooks/useWorkspaceAgent.spec.ts
@@ -112,7 +112,7 @@ describe('useWorkspaceAgent hosted console restore', () => {
     mocks.isDesktopRuntime.mockReturnValue(true)
   })
 
-  it('waits for portal restore before streaming hosted console messages', async () => {
+  it('shows the user message immediately while portal restore is pending', async () => {
     const { useWorkspaceAgent } = await import('./useWorkspaceAgent')
     const settings = createHostedConsoleSettings()
     const onError = vi.fn()
@@ -145,6 +145,10 @@ describe('useWorkspaceAgent hosted console restore', () => {
     })
     expect(mocks.ensurePortalAccountSessionRestored).toHaveBeenCalledTimes(1)
     expect(mocks.streamAgentMessage).not.toHaveBeenCalled()
+    expect(latest.agentDrafts[10]).toBe('')
+    expect(latest.agentMessages[10]).toEqual([
+      expect.objectContaining({ role: 'user', content: 'hello hosted console' }),
+    ])
 
     await act(async () => {
       resolveRestore({ access_token: 'portal-token' })
@@ -281,6 +285,9 @@ describe('useWorkspaceAgent hosted console restore', () => {
     expect(ensureHostedAccountReady).toHaveBeenCalledTimes(1)
     expect(mocks.ensurePortalAccountSessionRestored).not.toHaveBeenCalled()
     expect(mocks.streamAgentMessage).not.toHaveBeenCalled()
+    expect(latest.agentMessages[12]).toEqual([
+      expect.objectContaining({ role: 'user', content: 'resume after sign-in' }),
+    ])
 
     await act(async () => {
       resolveReady(true)
@@ -371,6 +378,96 @@ describe('useWorkspaceAgent hosted console restore', () => {
 
     expect(ensureHostedAccountReady).not.toHaveBeenCalled()
     expect(mocks.streamAgentMessage).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      root?.unmount()
+    })
+    container.remove()
+  })
+
+  it('does not wait for workspace document discovery when a message has no mentions', async () => {
+    const { useWorkspaceAgent } = await import('./useWorkspaceAgent')
+    mocks.listWorkspaceDocuments.mockImplementation(() => new Promise(() => {}))
+    let latest: any = null
+
+    function Harness() {
+      latest = useWorkspaceAgent({
+        settings: createOpenAISettings(),
+        rootPath: '/test/workspace',
+        onError: vi.fn(),
+        onFeedback: vi.fn(),
+      })
+      return null
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    let root: Root | null = null
+    await act(async () => {
+      root = createRoot(container)
+      root.render(createElement(Harness))
+    })
+    await act(async () => {
+      latest.setAgentDraft(16, 'hello')
+    })
+    await act(async () => {
+      latest.sendAiComposerMessage(16)
+      await flushAsyncWork()
+    })
+
+    expect(mocks.streamAgentMessage).toHaveBeenCalledTimes(1)
+    expect(mocks.streamAgentMessage.mock.calls[0][0].content).toBe('hello')
+
+    await act(async () => {
+      root?.unmount()
+    })
+    container.remove()
+  })
+
+  it('binds every turn to the current document without requiring an explicit mention', async () => {
+    const { useWorkspaceAgent } = await import('./useWorkspaceAgent')
+    let latest: any = null
+
+    function Harness() {
+      latest = useWorkspaceAgent({
+        settings: createOpenAISettings(),
+        rootPath: '/test/workspace',
+        onError: vi.fn(),
+        onFeedback: vi.fn(),
+        getTurnContext: () => ({
+          activeDocumentPath: 'Docs/Current.md',
+          activeDocumentFormat: 'markdown',
+          activeDataDocumentId: 0,
+          activeDataTableId: 0,
+        }),
+      })
+      return null
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    let root: Root | null = null
+    await act(async () => {
+      root = createRoot(container)
+      root.render(createElement(Harness))
+    })
+    await act(async () => {
+      latest.setAgentDraft(15, 'What should I improve?')
+    })
+    await act(async () => {
+      latest.sendAiComposerMessage(15)
+      await flushAsyncWork()
+    })
+
+    expect(mocks.streamAgentMessage).toHaveBeenCalledTimes(1)
+    expect(mocks.streamAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
+      activeDocumentPath: 'Docs/Current.md',
+      content: 'What should I improve?',
+      promptContext: expect.stringContaining(
+        'Read this exact path with document_read and analyze it before responding',
+      ),
+      saveMarkdown: false,
+    }))
 
     await act(async () => {
       root?.unmount()

--- a/src/features/agent/hooks/useWorkspaceAgent.ts
+++ b/src/features/agent/hooks/useWorkspaceAgent.ts
@@ -23,6 +23,7 @@ import {
 import { getCurrentLocale, getLanguageNameForLocale } from '@/i18n'
 import {
   buildAgentDocumentMentionPromptContext,
+  extractAgentDocumentMentionTokens,
   flattenMentionableWorkspaceDocuments,
   isBinaryAttachmentMention,
   resolveAgentDocumentMentions,
@@ -36,7 +37,11 @@ import {
 import { ensurePortalAccountSessionRestored } from '@/services/portalAccount'
 import { formatAgentToolName } from '@/features/agent/lib/agentTimeline'
 import { getAgentTimelineDict } from '@/features/agent/lib/agentTimelineI18n'
-import { isDesktopRuntime, listWorkspaceDocuments } from '@/services/desktop'
+import {
+  isDesktopRuntime,
+  listWorkspaceDocuments,
+  type WorkspaceDocumentFormat,
+} from '@/services/desktop'
 import { saveDesktopSettings } from '@/services/desktopSettings'
 import { notifyFromAgentEvent } from '@/services/desktopNotifications'
 import type { DesktopSettingsState } from '@/types/desktopSettings'
@@ -44,6 +49,8 @@ import { trackProductEventOnce } from '@/features/analytics/lib/productAnalytics
 import { isWebPreviewMode } from '@/lib/runtimeMode'
 
 type WorkspaceAgentTurnContext = {
+  activeDocumentPath?: string
+  activeDocumentFormat?: WorkspaceDocumentFormat
   activeDataDocumentId?: number | null
   activeDataTableId?: number | null
   browserContext?: AgentBrowserContext
@@ -243,7 +250,8 @@ export function useWorkspaceAgent({
       return
     }
     void refreshAgentSessions(undefined, { silent: silentInitialSessionLoad })
-  }, [refreshAgentSessions, rootPath, silentInitialSessionLoad])
+    void refreshMentionableDocuments()
+  }, [refreshAgentSessions, refreshMentionableDocuments, rootPath, silentInitialSessionLoad])
 
   const openAgentSession = useCallback(async (session: AgentSession) => {
     if (!agentMessages[session.id]) {
@@ -365,23 +373,6 @@ export function useWorkspaceAgent({
       return
     }
     agentSendInFlightSessions.current.add(sessionId)
-    if (selectedAgentModel.providerKind === 'kition_console') {
-      try {
-        if (ensureHostedAccountReady) {
-          const ready = await ensureHostedAccountReady()
-          if (!ready) {
-            agentSendInFlightSessions.current.delete(sessionId)
-            return
-          }
-        } else {
-          await ensurePortalAccountSessionRestored()
-        }
-      } catch (error) {
-        agentSendInFlightSessions.current.delete(sessionId)
-        onError(error instanceof Error ? error.message : 'Sign in to Kition before using Kition Cloud models.')
-        return
-      }
-    }
 
     const optimisticUserMessage: AgentMessage = {
       id: Date.now() * -1,
@@ -404,47 +395,100 @@ export function useWorkspaceAgent({
         : [...(current[sessionId] || []), optimisticUserMessage],
     }))
     setAgentStreamingText((current) => ({ ...current, [sessionId]: '' }))
-    markSessionBusy(sessionId, true)
-    trackProductEventOnce('agent_first_request_started')
     onError('')
     onFeedback('')
 
-    const abortController = new AbortController()
-    agentAbortControllers.current[sessionId] = abortController
-    let availableMentionableDocuments = mentionableDocuments
-    if (!availableMentionableDocuments.length) {
-      try {
-        const response = await listWorkspaceDocuments()
-        availableMentionableDocuments = flattenMentionableWorkspaceDocuments(response.items || [])
-        setMentionableDocuments(availableMentionableDocuments)
-      } catch {
-        availableMentionableDocuments = []
+    const rollbackPendingSend = () => {
+      if (!followup?.hideUserMessage) {
+        setAgentMessages((current) => {
+          const remaining = (current[sessionId] || []).filter(
+            (message) => message.id !== optimisticUserMessage.id,
+          )
+          if (remaining.length) {
+            return { ...current, [sessionId]: remaining }
+          }
+          const next = { ...current }
+          delete next[sessionId]
+          return next
+        })
+      }
+      if (followup?.content === undefined) {
+        setAgentDrafts((current) => ({
+          ...current,
+          [sessionId]: current[sessionId]?.trim() ? current[sessionId] : content,
+        }))
       }
     }
-    const mentionResolution = resolveAgentDocumentMentions({
-      content,
-      documents: availableMentionableDocuments,
-    })
-    const promptContext = buildAgentDocumentMentionPromptContext({
-      referencedDocuments: mentionResolution.resolved,
-      unresolvedTokens: mentionResolution.unresolved,
-    })
-    const attachmentPaths = mentionResolution.resolved
-      .filter((document) => document.kind !== 'folder' && isBinaryAttachmentMention(document.format, document.path))
-      .map((document) => document.path)
-    const { requestActiveDocumentPath, saveMarkdown } =
-      resolveAgentDocumentTarget({
-        currentDocumentPath: '',
-        referencedDocuments: mentionResolution.resolved,
-        bindDocumentContext: false,
-        allowSaveMarkdown: true,
-      })
 
-    const turnContext = (await getTurnContext?.()) || undefined
+    if (selectedAgentModel.providerKind === 'kition_console') {
+      try {
+        if (ensureHostedAccountReady) {
+          const ready = await ensureHostedAccountReady()
+          if (!ready) {
+            agentSendInFlightSessions.current.delete(sessionId)
+            rollbackPendingSend()
+            return
+          }
+        } else {
+          await ensurePortalAccountSessionRestored()
+        }
+      } catch (error) {
+        agentSendInFlightSessions.current.delete(sessionId)
+        rollbackPendingSend()
+        onError(error instanceof Error ? error.message : 'Sign in to Kition before using Kition Cloud models.')
+        return
+      }
+    }
+    markSessionBusy(sessionId, true)
+    trackProductEventOnce('agent_first_request_started')
 
+    const abortController = new AbortController()
+    agentAbortControllers.current[sessionId] = abortController
     let tableMutated = false
 
     try {
+      const turnContext = (await getTurnContext?.()) || undefined
+      const activeDocumentPath = String(turnContext?.activeDocumentPath || '').trim()
+      const mentionTokens = extractAgentDocumentMentionTokens(content)
+      let availableMentionableDocuments = mentionableDocuments
+      if (mentionTokens.length && !availableMentionableDocuments.length) {
+        try {
+          const response = await listWorkspaceDocuments()
+          availableMentionableDocuments = flattenMentionableWorkspaceDocuments(response.items || [])
+          setMentionableDocuments(availableMentionableDocuments)
+        } catch {
+          availableMentionableDocuments = []
+        }
+      }
+      const mentionResolution = resolveAgentDocumentMentions({
+        content,
+        documents: availableMentionableDocuments,
+      })
+      const promptContext = buildAgentDocumentMentionPromptContext({
+        activeDocumentPath,
+        activeDocumentFormat: turnContext?.activeDocumentFormat,
+        referencedDocuments: mentionResolution.resolved,
+        unresolvedTokens: mentionResolution.unresolved,
+      })
+      const attachmentPaths = Array.from(new Set([
+        ...(isBinaryAttachmentMention(turnContext?.activeDocumentFormat, activeDocumentPath)
+          ? [activeDocumentPath]
+          : []),
+        ...mentionResolution.resolved
+          .filter(
+            (document) => document.kind !== 'folder'
+              && isBinaryAttachmentMention(document.format, document.path),
+          )
+          .map((document) => document.path),
+      ]))
+      const { requestActiveDocumentPath, saveMarkdown } =
+        resolveAgentDocumentTarget({
+          currentDocumentPath: activeDocumentPath,
+          referencedDocuments: mentionResolution.resolved,
+          bindDocumentContext: Boolean(activeDocumentPath),
+          allowSaveMarkdown: true,
+        })
+
       const done = await streamAgentMessage({
         sessionId,
         content,

--- a/src/features/agent/lib/agentTurnContext.ts
+++ b/src/features/agent/lib/agentTurnContext.ts
@@ -2,10 +2,13 @@ import type { AgentBrowserContext, AgentPaneContext, AgentTaskMode } from '@/api
 import type {
   BrowserPageContext,
   BrowserSessionProvider,
+  WorkspaceDocumentFormat,
 } from '@/services/desktop'
 import type { DataDocument, DataTable } from '@/types/dataDocument'
 
 export type AgentTurnContext = {
+  activeDocumentPath: string
+  activeDocumentFormat?: WorkspaceDocumentFormat
   activeDataDocumentId: number
   activeDataTableId: number
   browserContext?: AgentBrowserContext
@@ -70,6 +73,8 @@ export function buildActiveBrowserTabContext(input: {
 }
 
 export function buildAgentTurnContext(input: {
+  activeDocumentPath?: string
+  activeDocumentFormat?: WorkspaceDocumentFormat
   activeDocument?: DataDocument | null
   activeTable?: DataTable | null
   browserContext?: AgentBrowserContext
@@ -77,6 +82,8 @@ export function buildAgentTurnContext(input: {
   activeWorkflowId?: string
 }): AgentTurnContext {
   return {
+    activeDocumentPath: String(input.activeDocumentPath || '').trim(),
+    activeDocumentFormat: input.activeDocumentFormat,
     activeDataDocumentId: input.activeDocument?.id ?? 0,
     activeDataTableId: input.activeTable?.id ?? 0,
     browserContext: input.browserContext,

--- a/src/features/agent/lib/documentMentions.spec.ts
+++ b/src/features/agent/lib/documentMentions.spec.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyAgentMentionSelection,
+  buildAgentDraftWithDocumentMentions,
   buildAgentDocumentMentionPromptContext,
   extractAgentDocumentMentionTokens,
   findAgentMentionQuery,
   flattenMentionableWorkspaceDocuments,
+  getUniqueAgentDocumentMentionPaths,
   parseAgentMentionSegments,
+  removeAgentDocumentMention,
   resolveAgentDocumentMentions,
+  stripAgentDocumentMentions,
 } from './documentMentions'
 
 describe('documentMentions', () => {
@@ -44,6 +48,13 @@ describe('documentMentions', () => {
         name: 'Plan.md',
         title: 'Plan',
         format: 'markdown',
+      },
+      {
+        kind: 'file',
+        path: 'Docs/Data.kitable',
+        name: 'Data.kitable',
+        title: 'Data',
+        format: 'data',
       },
     ])
   })
@@ -105,6 +116,22 @@ describe('documentMentions', () => {
     })
   })
 
+  it('stores document mentions separately from visible composer text', () => {
+    const draft = buildAgentDraftWithDocumentMentions('Analyze this file', [
+      'Getting Started/Guides/Product Content/Product Content Studio.kitable',
+      'Notes/Todo.md',
+    ])
+
+    expect(stripAgentDocumentMentions(draft)).toBe('Analyze this file')
+    expect(getUniqueAgentDocumentMentionPaths(draft)).toEqual([
+      'Getting Started/Guides/Product Content/Product Content Studio.kitable',
+      'Notes/Todo.md',
+    ])
+    expect(removeAgentDocumentMention(draft, 'Notes/Todo.md')).toBe(
+      'Analyze this file\n@{Getting Started/Guides/Product Content/Product Content Studio.kitable}',
+    )
+  })
+
   it('builds explicit prompt context for referenced docs', () => {
     expect(buildAgentDocumentMentionPromptContext({
       referencedDocuments: [
@@ -118,6 +145,19 @@ describe('documentMentions', () => {
       ],
       unresolvedTokens: ['Unknown'],
     })).toContain('Referenced workspace documents in this turn:')
+  })
+
+  it('requires analysis of the current document without an explicit mention', () => {
+    const context = buildAgentDocumentMentionPromptContext({
+      activeDocumentPath: 'Docs/Current.md',
+      activeDocumentFormat: 'markdown',
+      referencedDocuments: [],
+    })
+
+    expect(context).toContain('Current workspace document for this turn:')
+    expect(context).toContain('Docs/Current.md')
+    expect(context).toContain('Read this exact path with document_read and analyze it before responding')
+    expect(context).toContain('Do not ask which document the user means')
   })
 
   it('builds a folders block instructing document_list for referenced folders', () => {

--- a/src/features/agent/lib/documentMentions.ts
+++ b/src/features/agent/lib/documentMentions.ts
@@ -24,6 +24,8 @@ export type AgentMentionQuery = {
 
 const mentionableFormats = new Set<WorkspaceDocumentFormat>([
   'markdown',
+  'data',
+  'table',
   'text',
   'html',
   'json',
@@ -96,7 +98,7 @@ export function isMentionableWorkspaceFormat(
   if (format && mentionableFormats.has(format)) {
     return true
   }
-  return /\.(md|markdown|txt|html|htm|json|csv|tsv|pdf|pptx?|docx?|xlsx?|png|jpe?g|gif|webp|svg)$/i.test(path)
+  return /\.(md|markdown|kitable|txt|html|htm|json|csv|tsv|pdf|pptx?|docx?|xlsx?|png|jpe?g|gif|webp|svg)$/i.test(path)
 }
 
 export function extractAgentDocumentMentionTokens(content: string) {
@@ -110,6 +112,43 @@ export function extractAgentDocumentMentionTokens(content: string) {
     }
   }
   return tokens
+}
+
+export function getUniqueAgentDocumentMentionPaths(content: string) {
+  return Array.from(new Set(extractAgentDocumentMentionTokens(content)))
+}
+
+export function stripAgentDocumentMentions(content: string) {
+  return content
+    .replace(/@\{([^}\n]+)\}/g, '')
+    .replace(/[ \t]+(?=\n)/g, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/\n[ \t]*$/, '')
+}
+
+export function buildAgentDraftWithDocumentMentions(
+  content: string,
+  paths: string[],
+) {
+  const uniquePaths = Array.from(
+    new Set(paths.map((path) => path.trim()).filter(Boolean)),
+  )
+  if (!uniquePaths.length) {
+    return content
+  }
+  const body = content.replace(/\n[ \t]*$/, '')
+  const mentionLine = uniquePaths.map((path) => `@{${path}}`).join(' ')
+  return body ? `${body}\n${mentionLine}` : mentionLine
+}
+
+export function removeAgentDocumentMention(content: string, path: string) {
+  const nextPaths = getUniqueAgentDocumentMentionPaths(content).filter(
+    (candidate) => candidate !== path,
+  )
+  return buildAgentDraftWithDocumentMentions(
+    stripAgentDocumentMentions(content),
+    nextPaths,
+  )
 }
 
 export function parseAgentMentionSegments(content: string): AgentMentionSegment[] {
@@ -251,13 +290,50 @@ export function resolveAgentDocumentMentions(input: {
 }
 
 export function buildAgentDocumentMentionPromptContext(input: {
+  activeDocumentPath?: string
+  activeDocumentFormat?: WorkspaceDocumentFormat
   referencedDocuments: AgentMentionableDocument[]
   unresolvedTokens?: string[]
 }) {
   const lines: string[] = []
-  const referencedFiles = input.referencedDocuments.filter((document) => document.kind !== 'folder')
+  const activeDocumentPath = String(input.activeDocumentPath || '').trim()
+  if (activeDocumentPath) {
+    lines.push('Current workspace document for this turn:')
+    lines.push(`- ${activeDocumentPath}`)
+    if (isBinaryAttachmentMention(input.activeDocumentFormat, activeDocumentPath)) {
+      lines.push(
+        'This current document is attached to the turn. Analyze it before responding; it is implicit context even without an @ mention.',
+      )
+    } else if (
+      input.activeDocumentFormat === 'data'
+      || input.activeDocumentFormat === 'table'
+      || activeDocumentPath.toLowerCase().endsWith('.kitable')
+    ) {
+      lines.push(
+        'Analyze the current structured document with the active table context before responding; it is implicit context even without an @ mention.',
+      )
+    } else {
+      lines.push(
+        'Read this exact path with document_read and analyze it before responding; it is implicit context even without an @ mention.',
+      )
+    }
+    lines.push(
+      'Do not ask which document the user means while this current document is available.',
+    )
+  }
+  const referencedFiles = input.referencedDocuments.filter(
+    (document) => document.kind !== 'folder' && document.path !== activeDocumentPath,
+  )
   const referencedFolders = input.referencedDocuments.filter((document) => document.kind === 'folder')
-  const textFiles = referencedFiles.filter((document) => !isBinaryAttachmentMention(document.format, document.path))
+  const structuredFiles = referencedFiles.filter(
+    (document) => document.format === 'data'
+      || document.format === 'table'
+      || document.path.toLowerCase().endsWith('.kitable'),
+  )
+  const textFiles = referencedFiles.filter(
+    (document) => !structuredFiles.includes(document)
+      && !isBinaryAttachmentMention(document.format, document.path),
+  )
   const binaryFiles = referencedFiles.filter((document) => isBinaryAttachmentMention(document.format, document.path))
   if (textFiles.length) {
     lines.push('Referenced workspace documents in this turn:')
@@ -278,6 +354,15 @@ export function buildAgentDocumentMentionPromptContext(input: {
     }
     lines.push(
       'Do NOT call document_read on these binary attachments — their contents are already provided in this turn (images as vision input, pdf/pptx/docx/xlsx as extracted text blocks).',
+    )
+  }
+  if (structuredFiles.length) {
+    lines.push('Referenced structured workspace documents in this turn:')
+    for (const document of structuredFiles) {
+      lines.push(`- ${document.path}`)
+    }
+    lines.push(
+      'Analyze each referenced structured document with the table/data tools available for its exact path before responding.',
     )
   }
   if (referencedFolders.length) {

--- a/src/features/workspace/components/WorkspaceScreen.tsx
+++ b/src/features/workspace/components/WorkspaceScreen.tsx
@@ -79,7 +79,10 @@ import {
   type WorkspaceTab,
   type WorkspaceTreeNode,
 } from '@/features/workspace/lib/workspace'
-import { deriveAgentPaneContext } from '@/features/workspace/lib/agentPaneContext'
+import {
+  deriveAgentPaneContext,
+  resolveAgentActiveDocument,
+} from '@/features/workspace/lib/agentPaneContext'
 import { moveWorkspaceTreeBranchMetadata } from '@/features/workspace/lib/workspaceTree'
 import {
   readWorkspaceAgentActiveSessionId,
@@ -364,6 +367,7 @@ export function WorkspaceScreen({
     modifiedPaths: new Set<string>(),
   })
   const agentTurnContextRef = useRef<AgentTurnContext>({
+    activeDocumentPath: '',
     activeDataDocumentId: 0,
     activeDataTableId: 0,
     taskMode: 'auto',
@@ -783,7 +787,10 @@ export function WorkspaceScreen({
     : null
   tableAgentRefreshRef.current = tableAgentContext?.onTableChanged ?? null
   const hasTableAgentTarget = Boolean(tableAgentDocumentPath)
+  const agentActiveDocument = resolveAgentActiveDocument(activeWorkspaceTab)
   agentTurnContextRef.current = buildAgentTurnContext({
+    activeDocumentPath: agentActiveDocument.path,
+    activeDocumentFormat: agentActiveDocument.format,
     activeDocument: tableAgentContext?.activeDocument,
     activeTable: tableAgentContext?.activeTable,
     browserContext: activeBrowserTab

--- a/src/features/workspace/lib/agentPaneContext.spec.ts
+++ b/src/features/workspace/lib/agentPaneContext.spec.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { WorkspaceTab } from '@/features/workspace/lib/workspace'
 
-import { deriveAgentPaneContext } from './agentPaneContext'
+import { deriveAgentPaneContext, resolveAgentActiveDocument } from './agentPaneContext'
 
 describe('deriveAgentPaneContext', () => {
   it('returns document when no tab is active so the empty state has sensible default copy', () => {
@@ -117,5 +117,36 @@ describe('deriveAgentPaneContext', () => {
       kind: 'images',
     }
     expect(deriveAgentPaneContext(tab)).toBe('gallery')
+  })
+})
+
+describe('resolveAgentActiveDocument', () => {
+  it('returns the path and format for document and file viewer tabs', () => {
+    expect(resolveAgentActiveDocument({
+      id: 'document:Docs/Plan.md',
+      type: 'document',
+      title: 'Plan',
+      path: 'Docs/Plan.md',
+      format: 'markdown',
+    })).toEqual({ path: 'Docs/Plan.md', format: 'markdown' })
+
+    expect(resolveAgentActiveDocument({
+      id: 'file:Reports/Quarter.pdf',
+      type: 'file-viewer',
+      title: 'Quarter',
+      path: 'Reports/Quarter.pdf',
+      format: 'pdf',
+    })).toEqual({ path: 'Reports/Quarter.pdf', format: 'pdf' })
+  })
+
+  it('keeps a table bound to its kitable document', () => {
+    expect(resolveAgentActiveDocument({
+      id: 'table:Leads.kitable#7',
+      type: 'table',
+      title: 'Leads',
+      kitablePath: 'Sales/Leads.kitable',
+      tableId: 7,
+      format: 'data',
+    })).toEqual({ path: 'Sales/Leads.kitable', format: 'data' })
   })
 })

--- a/src/features/workspace/lib/agentPaneContext.ts
+++ b/src/features/workspace/lib/agentPaneContext.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceTab } from '@/features/workspace/lib/workspace'
+import type { WorkspaceDocumentFormat } from '@/services/desktop'
 import type { AgentPaneContext } from '@/features/agent/lib/paneEmptyState'
 
 // deriveAgentPaneContext maps a workbench tab to the agent panel's pane
@@ -66,6 +67,41 @@ export function deriveAgentPaneContext(
       const _exhaustive: never = tab
       void _exhaustive
       return 'document'
+    }
+  }
+}
+
+export function resolveAgentActiveDocument(
+  tab: WorkspaceTab | null | undefined,
+): { path: string; format?: WorkspaceDocumentFormat } {
+  if (!tab) {
+    return { path: '' }
+  }
+  switch (tab.type) {
+    case 'document':
+    case 'file-viewer':
+      return { path: tab.path, format: tab.format }
+    case 'table':
+      return { path: tab.kitablePath, format: 'data' }
+    case 'workflow':
+      return {
+        path: tab.kitablePath || '',
+        format: tab.kitablePath ? 'data' : undefined,
+      }
+    case 'browser':
+      return {
+        path: tab.originDocumentPath || '',
+        format: tab.originDocumentPath?.toLowerCase().endsWith('.kitable')
+          ? 'data'
+          : undefined,
+      }
+    case 'browser-sites':
+    case 'gallery':
+      return { path: '' }
+    default: {
+      const _exhaustive: never = tab
+      void _exhaustive
+      return { path: '' }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Show user messages immediately before Kition Cloud account readiness checks complete, and avoid blocking messages without mentions on workspace document discovery.
- Bind every Agent turn to the active workspace document, including structured and binary document context, so the Agent does not ask which open document to analyze.
- Replace visible raw `@{path}` tokens with compact file-name references, removable single-file controls, and a select-style control for multiple references.
- Split the Agent composer and document-reference UI into focused Agent components.

## Validation

- `pnpm run build:check`
- `pnpm test:unit` — 238 test files, 3326 tests passed
- `python3 scripts/check-i18n.py`
- `pnpm test:table:e2e` — 13 tests passed