### PR TITLE
Release Kition 0.1.2

### DIFF
--- a/electron/runtime.lock.json
+++ b/electron/runtime.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "runtimeVersion": "0.1.1",
+  "runtimeVersion": "0.1.2",
   "protocolVersion": 1,
-  "releaseTag": "v0.1.1",
+  "releaseTag": "v0.1.2",
   "repository": "KitionAI/kition-dev"
 }

--- a/electron/scripts/build-sidecar.spec.ts
+++ b/electron/scripts/build-sidecar.spec.ts
@@ -31,7 +31,7 @@ describe('buildSidecar', () => {
     const result = await buildSidecar(output, 'darwin', 'arm64')
 
     expect(result.source).toBe('explicit')
-    expect(result.runtimeVersion).toBe('0.1.1')
+    expect(result.runtimeVersion).toBe('0.1.2')
     expect(result.protocolVersion).toBe(1)
     expect(await fs.readFile(result.outputPath, 'utf8')).toContain('exit 0')
     expect(result.sha256).toBe(createHash('sha256').update(await fs.readFile(result.outputPath)).digest('hex'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kition",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Kition — documents, structured tables, AI agents, and visual workflows",

--- a/src/features/workflow/components/launcher/WorkflowLauncher.spec.tsx
+++ b/src/features/workflow/components/launcher/WorkflowLauncher.spec.tsx
@@ -15,6 +15,8 @@ import * as router from '@/features/workflow/lib/openWorkflowRoute'
 import { WorkflowLauncher } from './WorkflowLauncher'
 import type { WorkflowLauncherProps } from './WorkflowLauncher'
 
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
 const tableContext = {
   documentId: 'doc1',
   tableId: 't1',
@@ -55,8 +57,11 @@ beforeEach(() => {
   vi.mocked(router.openWorkflowHome).mockReset()
 })
 
-afterEach(() => {
-  root?.unmount()
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount()
+  })
+  root = null
   container.remove()
 })
 


### PR DESCRIPTION
## Summary
- bump the public client version to 0.1.2
- align the pinned runtime version and release tag
- update the sidecar packaging expectation

## Validation
- pnpm run lint
- pnpm run check:security
- pnpm run build:check
- pnpm test
- KITION_E2E_PORT=3212 pnpm run test:e2e
- pnpm run test:desktop:e2e
- python3 scripts/check-i18n.py
- python3 scripts/check-branding.py
- pnpm test:table:e2e