### PR TITLE
Handle package registry audit errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "check:runtime-lock": "node electron/scripts/validate-runtime-lock.mjs",
     "check:desktop-assets": "node electron/scripts/validate-desktop-assets.mjs",
     "check:notices": "node scripts/generate-third-party-notices.mjs --check",
-    "check:security": "python3 scripts/check-secrets.py && pnpm audit --audit-level high",
+    "check:security": "python3 scripts/check-secrets.py && pnpm audit --audit-level high --ignore-registry-errors",
     "notices:generate": "node scripts/generate-third-party-notices.mjs",
     "build:perf": "pnpm run build && pnpm perf:budget",
     "build:electron": "node electron/scripts/build-electron.mjs",


### PR DESCRIPTION
## Summary
- keep high and critical dependency advisories blocking CI
- allow pnpm audit registry transport and response errors to remain non-blocking
- preserve the tracked-secret scan as a required check

## Context
The npm audit endpoint repeatedly returned gzip data that pnpm could not parse as JSON. pnpm provides this option specifically for registry failures in CI.

## Validation
- pnpm run check:security
- pnpm run lint
- pnpm run build:check
- python3 scripts/check-i18n.py
- pnpm test:table:e2e