### PR TITLE
perf(agent): keep context UI within CSS budget

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1522,10 +1522,6 @@
     @apply relative flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden;
   }
 
-  .workspace-screen-editor {
-    @apply flex h-full min-h-0 min-w-0 flex-col overflow-hidden;
-  }
-
   .workspace-kitable-sidebar {
     @apply flex h-full min-h-0 w-[216px] shrink-0 flex-col overflow-hidden border-r;
     background: var(--document-sidebar-surface, hsl(var(--surface-soft)));
@@ -3942,99 +3938,6 @@
   .agent-ai-composer.is-compact {
     @apply max-w-none rounded-xl border bg-card p-3.5 shadow-none;
     border-color: var(--document-border, hsl(var(--border)));
-  }
-
-  .agent-context-tray {
-    @apply mb-2 flex flex-col gap-1 border-b pb-2;
-    border-bottom-color: var(--document-border, hsl(var(--border)));
-  }
-
-  .agent-context-tray__header {
-    @apply flex min-h-6 items-center gap-2;
-  }
-
-  .agent-context-tray__header > span {
-    @apply text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground;
-  }
-
-  .agent-context-add {
-    @apply relative shrink-0;
-  }
-
-  .agent-context-add__trigger {
-    @apply inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-45;
-  }
-
-  .agent-context-add__menu {
-    @apply absolute bottom-[calc(100%+8px)] left-0 z-30 w-60 overflow-hidden rounded-xl border bg-card p-1 shadow-lg;
-    border-color: var(--document-border, hsl(var(--border)));
-  }
-
-  .agent-context-add__menu > button {
-    @apply flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-45;
-  }
-
-  .agent-context-add__menu > button > svg {
-    @apply shrink-0 text-muted-foreground;
-  }
-
-  .agent-context-add__menu > button > span {
-    @apply flex min-w-0 flex-1 flex-col;
-  }
-
-  .agent-context-add__menu strong {
-    @apply text-xs font-medium text-foreground;
-  }
-
-  .agent-context-add__menu small {
-    @apply text-[11px] text-muted-foreground;
-  }
-
-  .agent-context-tray__items {
-    @apply flex min-w-0 flex-wrap content-start gap-1.5 overflow-y-auto pr-1;
-    max-height: 3.875rem;
-    overscroll-behavior: contain;
-    scrollbar-width: thin;
-    scrollbar-color: hsl(var(--muted-foreground) / 0.28) transparent;
-  }
-
-  .agent-context-tray__items::-webkit-scrollbar {
-    width: 4px;
-  }
-
-  .agent-context-tray__items::-webkit-scrollbar-thumb {
-    @apply rounded-full;
-    background: hsl(var(--muted-foreground) / 0.28);
-  }
-
-  .agent-context-chip {
-    @apply flex h-7 min-w-0 max-w-[14rem] items-center overflow-hidden rounded-md border bg-secondary text-xs text-foreground;
-    border-color: var(--document-border, hsl(var(--border)));
-  }
-
-  .agent-context-chip.is-document {
-    @apply bg-card;
-  }
-
-  .agent-context-chip.is-source {
-    @apply bg-card;
-  }
-
-  .agent-context-chip__main {
-    @apply flex h-full min-w-0 items-center gap-1.5 px-2 text-left;
-  }
-
-  button.agent-context-chip__main {
-    @apply transition-colors hover:bg-muted/60;
-  }
-
-  .agent-context-chip__main > span {
-    @apply min-w-0 truncate font-medium;
-  }
-
-  .agent-context-chip__remove {
-    @apply grid h-full w-7 shrink-0 place-items-center border-l text-muted-foreground transition-colors hover:bg-muted hover:text-foreground;
-    border-left-color: var(--document-border, hsl(var(--border)));
   }
 
   .agent-changed-files {

--- a/src/features/agent/components/AgentContextAddMenu.tsx
+++ b/src/features/agent/components/AgentContextAddMenu.tsx
@@ -43,10 +43,10 @@ export function AgentContextAddMenu({
   }, [menuOpen])
 
   return (
-    <div className="agent-context-add" ref={menuRef}>
+    <div className="agent-context-add relative shrink-0" ref={menuRef}>
       <button
         type="button"
-        className="agent-context-add__trigger"
+        className="agent-context-add__trigger inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-45"
         onClick={() => setMenuOpen((current) => !current)}
         disabled={disabled}
         aria-label={t('analysisWorkspace.addContext')}
@@ -57,10 +57,15 @@ export function AgentContextAddMenu({
         <Plus className="size-4" aria-hidden="true" />
       </button>
       {menuOpen ? (
-        <div className="agent-context-add__menu" role="menu">
+        <div
+          className="agent-context-add__menu absolute bottom-[calc(100%+8px)] left-0 z-30 w-60 overflow-hidden rounded-xl border bg-card p-1 shadow-lg"
+          role="menu"
+          style={{ borderColor: 'var(--document-border, hsl(var(--border)))' }}
+        >
           {onAddLocalSource ? (
             <button
               type="button"
+              className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-45"
               role="menuitem"
               onClick={() => {
                 setMenuOpen(false)
@@ -68,25 +73,26 @@ export function AgentContextAddMenu({
               }}
               disabled={localSourceCount >= 8}
             >
-              <FolderPlus className="size-4" aria-hidden="true" />
-              <span>
-                <strong>{t('analysisWorkspace.localFolder')}</strong>
-                <small>{t('analysisWorkspace.readOnly')}</small>
+              <FolderPlus className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <span className="flex min-w-0 flex-1 flex-col">
+                <strong className="text-xs font-medium text-foreground">{t('analysisWorkspace.localFolder')}</strong>
+                <small className="text-[11px] text-muted-foreground">{t('analysisWorkspace.readOnly')}</small>
               </span>
             </button>
           ) : null}
           <button
             type="button"
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-foreground transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-45"
             role="menuitem"
             onClick={() => {
               setMenuOpen(false)
               onRequestDocumentReference()
             }}
           >
-            <FileText className="size-4" aria-hidden="true" />
-            <span>
-              <strong>{t('analysisWorkspace.workspaceDocument')}</strong>
-              <small>{t('analysisWorkspace.referenceDocument')}</small>
+            <FileText className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <span className="flex min-w-0 flex-1 flex-col">
+              <strong className="text-xs font-medium text-foreground">{t('analysisWorkspace.workspaceDocument')}</strong>
+              <small className="text-[11px] text-muted-foreground">{t('analysisWorkspace.referenceDocument')}</small>
             </span>
           </button>
         </div>

--- a/src/features/agent/components/AgentContextTray.tsx
+++ b/src/features/agent/components/AgentContextTray.tsx
@@ -35,12 +35,26 @@ export function AgentContextTray({
   }
 
   return (
-    <div className="agent-context-tray" data-testid="agent-context-tray">
-      <div className="agent-context-tray__header">
-        <span>{t('analysisWorkspace.contextTitle')}</span>
+    <div
+      className="agent-context-tray mb-2 flex flex-col gap-1 border-b pb-2"
+      data-testid="agent-context-tray"
+      style={{ borderColor: 'var(--document-border, hsl(var(--border)))' }}
+    >
+      <div className="agent-context-tray__header flex min-h-6 items-center gap-2">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          {t('analysisWorkspace.contextTitle')}
+        </span>
       </div>
 
-      <div className="agent-context-tray__items">
+      <div
+        className="agent-context-tray__items flex min-w-0 flex-wrap content-start gap-1.5 overflow-y-auto pr-1"
+        style={{
+          maxHeight: '3.875rem',
+          overscrollBehavior: 'contain',
+          scrollbarColor: 'hsl(var(--muted-foreground) / 0.28) transparent',
+          scrollbarWidth: 'thin',
+        }}
+      >
         {documents.map((document) => (
           <ContextChip
             key={document.path}
@@ -95,25 +109,39 @@ function ContextChip({
   const content = (
     <>
       {icon}
-      <span>{label}</span>
+      <span className="min-w-0 truncate font-medium">{label}</span>
     </>
   )
   return (
-    <div className={cn('agent-context-chip', className)} title={title}>
+    <div
+      className={cn(
+        'agent-context-chip flex h-7 min-w-0 max-w-[14rem] items-center overflow-hidden rounded-md border bg-card text-xs text-foreground',
+        className,
+      )}
+      title={title}
+      style={{ borderColor: 'var(--document-border, hsl(var(--border)))' }}
+    >
       {onOpen ? (
-        <button type="button" className="agent-context-chip__main" onClick={onOpen}>
+        <button
+          type="button"
+          className="agent-context-chip__main flex h-full min-w-0 items-center gap-1.5 px-2 text-left transition-colors hover:bg-muted/60"
+          onClick={onOpen}
+        >
           {content}
         </button>
       ) : (
-        <span className="agent-context-chip__main">{content}</span>
+        <span className="agent-context-chip__main flex h-full min-w-0 items-center gap-1.5 px-2 text-left">
+          {content}
+        </span>
       )}
       {onRemove ? (
         <button
           type="button"
-          className="agent-context-chip__remove"
+          className="agent-context-chip__remove grid h-full w-7 shrink-0 place-items-center border-l text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           onClick={onRemove}
           aria-label={removeLabel}
           title={removeLabel}
+          style={{ borderColor: 'var(--document-border, hsl(var(--border)))' }}
         >
           <X className="size-3" aria-hidden="true" />
         </button>

--- a/src/features/workspace/components/WorkspaceScreenEditor.tsx
+++ b/src/features/workspace/components/WorkspaceScreenEditor.tsx
@@ -11,7 +11,7 @@ export function WorkspaceScreenEditor({
   editorContentProps,
 }: WorkspaceScreenEditorProps) {
   return (
-    <div className="workspace-screen-editor">
+    <div className="workspace-screen-editor flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
       <WorkspaceEditorPane>
         <WorkspaceEditorContent {...editorContentProps} />
       </WorkspaceEditorPane>


### PR DESCRIPTION
## Summary

- move Agent context tray/menu layout utilities from dedicated global selectors into component utility classes
- preserve semantic class names for tests and diagnostics while removing duplicated compiled CSS
- keep document border tokens through scoped inline style values and retain the same interaction/layout behavior

## Release context

The `v0.1.23` unified release was safely blocked before installer builds because the production initial CSS measured about 383.4 KB against the 380 KB budget. The public `v0.1.23` Release remains a draft. This change reduces the built initial CSS to 378,451 bytes without raising the budget. Because the `v0.1.23` tag is immutable, the next release will be `v0.1.24` after this PR merges.

## Validation

- `pnpm run check` — 315 test files, 3,682 tests passed
- `KITION_E2E_PORT=35671 pnpm run test:e2e` — 32 tests passed with a fresh server
- `pnpm test:table:e2e` — 13 tests passed
- `pnpm run perf:budget` — passed; initial CSS 378,451 bytes
- focused Agent context component tests — 37 tests passed
- branding, i18n, secrets, host-path, and diff checks passed

## Security and runtime boundary

No contract, IPC, permission, credential, network, dependency, or private runtime behavior changes. This is a client-only stylesheet deduplication and component presentation refactor.
