### PR TITLE
fix(agent): prioritize active tab in mentions

### DIFF
--- a/src/features/agent/components/AgentAiComposer.spec.tsx
+++ b/src/features/agent/components/AgentAiComposer.spec.tsx
@@ -75,6 +75,31 @@ describe('AgentAiComposer document mentions', () => {
     expect(currentRow?.textContent).toContain('Attached')
   })
 
+  it('marks an equivalent active tab path as current and attached beyond the initial limit', async () => {
+    const current = makeDocument('Docs/Current.md', 'Current')
+    const documents = [
+      ...Array.from({ length: 20 }, (_, index) => makeDocument(
+        `Docs/Document-${index + 1}.md`,
+        `Document ${index + 1}`,
+      )),
+      current,
+    ]
+    await mount(makeProps({
+      currentDocumentPath: 'docs\\current.md',
+      documentContextPaths: ['docs\\current.md'],
+      draft: '@',
+      mentionableDocuments: documents,
+    }))
+
+    const mentionRows = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-mention-path]'),
+    )
+    expect(mentionRows[0]?.dataset.mentionPath).toBe(current.path)
+    expect(mentionRows[0]?.classList.contains('is-attached')).toBe(true)
+    expect(mentionRows[0]?.textContent).toContain('Current')
+    expect(mentionRows[0]?.textContent).toContain('Attached')
+  })
+
   it('searches documents beyond the initial suggestion limit and adds the highlighted result', async () => {
     Element.prototype.scrollIntoView = vi.fn()
     const target = makeDocument('Archive/Needle.md', 'Needle')

--- a/src/features/agent/components/AgentAiComposer.tsx
+++ b/src/features/agent/components/AgentAiComposer.tsx
@@ -12,6 +12,7 @@ import type { KitionAccountStatus } from '@/features/account/hooks/useKitionAcco
 import type { AgentModelOption } from '@/features/agent/lib/agentConfig'
 import {
   findAgentMentionQuery,
+  resolveAgentMentionDocumentPath,
   searchAgentMentionableDocuments,
   stripAgentDocumentMentions,
   type AgentMentionableDocument,
@@ -86,12 +87,25 @@ export function AgentAiComposer({
   const documentsByPath = new Map(
     mentionableDocuments.map((document) => [document.path, document]),
   )
-  const contextDocuments = documentContextPaths.map((path) => ({
-    path,
-    kind: documentsByPath.get(path)?.kind,
-    current: path === currentDocumentPath,
-  }))
-  const currentDocument = documentsByPath.get(currentDocumentPath)
+  const resolvedCurrentDocumentPath = resolveAgentMentionDocumentPath(
+    mentionableDocuments,
+    currentDocumentPath,
+  )
+  const resolvedContextDocumentPaths = documentContextPaths.map((path) => (
+    resolveAgentMentionDocumentPath(mentionableDocuments, path)
+  ))
+  const attachedDocumentPaths = new Set(resolvedContextDocumentPaths)
+  const contextDocuments = documentContextPaths.map((path, index) => {
+    const resolvedPath = resolvedContextDocumentPaths[index]
+    return {
+      path,
+      kind: documentsByPath.get(resolvedPath)?.kind,
+      current: Boolean(
+        resolvedCurrentDocumentPath && resolvedPath === resolvedCurrentDocumentPath,
+      ),
+    }
+  })
+  const currentDocument = documentsByPath.get(resolvedCurrentDocumentPath)
   useEffect(() => {
     function handle() {
       requestAnimationFrame(() => {
@@ -128,7 +142,7 @@ export function AgentAiComposer({
     mentionQuery?.query.trim() ? 50 : 16,
   )
   const selectableMentions = visibleMentions.filter(
-    (document) => !documentContextPaths.includes(document.path),
+    (document) => !attachedDocumentPaths.has(document.path),
   )
   const highlightedMention = selectableMentions[highlightedMentionIndex]
   const mentionMenuOpen = Boolean(mentionQuery && !mentionMenuDismissed)
@@ -154,7 +168,7 @@ export function AgentAiComposer({
     if (!mentionQuery) {
       return
     }
-    if (documentContextPaths.includes(document.path)) {
+    if (attachedDocumentPaths.has(document.path)) {
       return
     }
     const head = visibleDraft.slice(0, mentionQuery.start)
@@ -286,8 +300,8 @@ export function AgentAiComposer({
               : t('mentions.searchHint')}
           </div>
           {visibleMentions.length ? visibleMentions.map((document) => {
-            const attached = documentContextPaths.includes(document.path)
-            const current = document.path === currentDocumentPath
+            const attached = attachedDocumentPaths.has(document.path)
+            const current = document.path === resolvedCurrentDocumentPath
             const active = highlightedMention?.path === document.path
             const content = (
               <>
@@ -351,7 +365,7 @@ export function AgentAiComposer({
           disabled={busy}
           currentDocumentTitle={currentDocument?.title}
           currentDocumentAttached={Boolean(
-            currentDocumentPath && documentContextPaths.includes(currentDocumentPath),
+            resolvedCurrentDocumentPath && attachedDocumentPaths.has(resolvedCurrentDocumentPath),
           )}
           localSourceCount={localSources.length}
           onAddCurrentDocument={currentDocument && onAddDocumentContext

--- a/src/features/agent/lib/documentMentions.spec.ts
+++ b/src/features/agent/lib/documentMentions.spec.ts
@@ -151,6 +151,25 @@ describe('documentMentions', () => {
     ])
   })
 
+  it('ranks the active tab first when its path uses equivalent separators and casing', () => {
+    const documents: AgentMentionableDocument[] = [
+      { kind: 'file', path: 'Docs/Other.md', name: 'Other.md', title: 'Other', format: 'markdown' },
+      { kind: 'file', path: 'Docs/Current.md', name: 'Current.md', title: 'Current', format: 'markdown' },
+      { kind: 'file', path: 'Docs/Recent.md', name: 'Recent.md', title: 'Recent', format: 'markdown' },
+    ]
+
+    expect(searchAgentMentionableDocuments({
+      documents,
+      query: '',
+      currentDocumentPath: 'docs\\current.md',
+      contextPaths: ['Docs/Recent.md'],
+    }).map((document) => document.path)).toEqual([
+      'Docs/Current.md',
+      'Docs/Recent.md',
+      'Docs/Other.md',
+    ])
+  })
+
   it('stores document mentions separately from visible composer text', () => {
     const draft = buildAgentDraftWithDocumentMentions('Analyze this file', [
       'Getting Started/Guides/Product Content/Product Content Studio.kitable',

--- a/src/features/agent/lib/documentMentions.spec.ts
+++ b/src/features/agent/lib/documentMentions.spec.ts
@@ -170,6 +170,38 @@ describe('documentMentions', () => {
     ])
   })
 
+  it('prefers an exact active path when case-folded paths are ambiguous', () => {
+    const documents: AgentMentionableDocument[] = [
+      { kind: 'file', path: 'Docs/current.md', name: 'current.md', title: 'lowercase', format: 'markdown' },
+      { kind: 'file', path: 'Docs/Current.md', name: 'Current.md', title: 'Current', format: 'markdown' },
+    ]
+
+    expect(searchAgentMentionableDocuments({
+      documents,
+      query: '',
+      currentDocumentPath: 'Docs/Current.md',
+    }).map((document) => document.path)).toEqual([
+      'Docs/Current.md',
+      'Docs/current.md',
+    ])
+  })
+
+  it('does not collapse compatibility characters when identifying the active path', () => {
+    const documents: AgentMentionableDocument[] = [
+      { kind: 'file', path: 'Docs/1.md', name: '1.md', title: 'One', format: 'markdown' },
+      { kind: 'file', path: 'Docs/①.md', name: '①.md', title: 'Circled one', format: 'markdown' },
+    ]
+
+    expect(searchAgentMentionableDocuments({
+      documents,
+      query: '',
+      currentDocumentPath: 'Docs/①.md',
+    }).map((document) => document.path)).toEqual([
+      'Docs/①.md',
+      'Docs/1.md',
+    ])
+  })
+
   it('stores document mentions separately from visible composer text', () => {
     const draft = buildAgentDraftWithDocumentMentions('Analyze this file', [
       'Getting Started/Guides/Product Content/Product Content Studio.kitable',

--- a/src/features/agent/lib/documentMentions.ts
+++ b/src/features/agent/lib/documentMentions.ts
@@ -229,6 +229,12 @@ function normalizeMentionSearchValue(value: string) {
   return value.normalize('NFKC').trim().toLocaleLowerCase()
 }
 
+function normalizeMentionDocumentPath(value: string) {
+  return normalizeMentionSearchValue(value)
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+}
+
 function withoutMentionableExtension(value: string) {
   return value.replace(/\.(?:md|markdown|kitable|txt|html?|json|csv|tsv|pdf|pptx?|docx?|xlsx?|png|jpe?g|gif|webp|svg)$/i, '')
 }
@@ -263,20 +269,25 @@ export function searchAgentMentionableDocuments({
   contextPaths = [],
 }: AgentMentionSearchInput) {
   const normalizedQuery = normalizeMentionSearchValue(query)
-  const contextOrder = new Map(contextPaths.map((path, index) => [path, index]))
+  const normalizedCurrentDocumentPath = normalizeMentionDocumentPath(currentDocumentPath)
+  const contextOrder = new Map(contextPaths.map((path, index) => [
+    normalizeMentionDocumentPath(path),
+    index,
+  ]))
   return documents
     .map((document, index) => ({
       document,
       index,
+      normalizedPath: normalizeMentionDocumentPath(document.path),
       score: scoreMentionDocument(document, normalizedQuery),
     }))
     .filter((candidate) => Number.isFinite(candidate.score))
     .sort((left, right) => {
-      const leftCurrent = left.document.path === currentDocumentPath ? 0 : 1
-      const rightCurrent = right.document.path === currentDocumentPath ? 0 : 1
+      const leftCurrent = left.normalizedPath === normalizedCurrentDocumentPath ? 0 : 1
+      const rightCurrent = right.normalizedPath === normalizedCurrentDocumentPath ? 0 : 1
       if (leftCurrent !== rightCurrent) return leftCurrent - rightCurrent
-      const leftContext = contextOrder.get(left.document.path) ?? Number.POSITIVE_INFINITY
-      const rightContext = contextOrder.get(right.document.path) ?? Number.POSITIVE_INFINITY
+      const leftContext = contextOrder.get(left.normalizedPath) ?? Number.POSITIVE_INFINITY
+      const rightContext = contextOrder.get(right.normalizedPath) ?? Number.POSITIVE_INFINITY
       if (leftContext !== rightContext) return leftContext - rightContext
       if (left.score !== right.score) return left.score - right.score
       if (left.document.kind !== right.document.kind) {

--- a/src/features/agent/lib/documentMentions.ts
+++ b/src/features/agent/lib/documentMentions.ts
@@ -226,13 +226,34 @@ export function findAgentMentionQuery(
 }
 
 function normalizeMentionSearchValue(value: string) {
-  return value.normalize('NFKC').trim().toLocaleLowerCase()
+  return value.normalize('NFKC').trim().toLowerCase()
 }
 
 function normalizeMentionDocumentPath(value: string) {
-  return normalizeMentionSearchValue(value)
+  return value.trim()
     .replace(/\\/g, '/')
     .replace(/^\.\//, '')
+}
+
+export function resolveAgentMentionDocumentPath(
+  documents: AgentMentionableDocument[],
+  path: string,
+) {
+  const normalizedPath = normalizeMentionDocumentPath(path)
+  if (!normalizedPath) {
+    return ''
+  }
+  const exactMatch = documents.find(
+    (document) => normalizeMentionDocumentPath(document.path) === normalizedPath,
+  )
+  if (exactMatch) {
+    return exactMatch.path
+  }
+  const foldedPath = normalizedPath.toLowerCase()
+  const foldedMatches = documents.filter(
+    (document) => normalizeMentionDocumentPath(document.path).toLowerCase() === foldedPath,
+  )
+  return foldedMatches.length === 1 ? foldedMatches[0].path : normalizedPath
 }
 
 function withoutMentionableExtension(value: string) {
@@ -269,25 +290,27 @@ export function searchAgentMentionableDocuments({
   contextPaths = [],
 }: AgentMentionSearchInput) {
   const normalizedQuery = normalizeMentionSearchValue(query)
-  const normalizedCurrentDocumentPath = normalizeMentionDocumentPath(currentDocumentPath)
+  const resolvedCurrentDocumentPath = resolveAgentMentionDocumentPath(
+    documents,
+    currentDocumentPath,
+  )
   const contextOrder = new Map(contextPaths.map((path, index) => [
-    normalizeMentionDocumentPath(path),
+    resolveAgentMentionDocumentPath(documents, path),
     index,
   ]))
   return documents
     .map((document, index) => ({
       document,
       index,
-      normalizedPath: normalizeMentionDocumentPath(document.path),
       score: scoreMentionDocument(document, normalizedQuery),
     }))
     .filter((candidate) => Number.isFinite(candidate.score))
     .sort((left, right) => {
-      const leftCurrent = left.normalizedPath === normalizedCurrentDocumentPath ? 0 : 1
-      const rightCurrent = right.normalizedPath === normalizedCurrentDocumentPath ? 0 : 1
+      const leftCurrent = left.document.path === resolvedCurrentDocumentPath ? 0 : 1
+      const rightCurrent = right.document.path === resolvedCurrentDocumentPath ? 0 : 1
       if (leftCurrent !== rightCurrent) return leftCurrent - rightCurrent
-      const leftContext = contextOrder.get(left.normalizedPath) ?? Number.POSITIVE_INFINITY
-      const rightContext = contextOrder.get(right.normalizedPath) ?? Number.POSITIVE_INFINITY
+      const leftContext = contextOrder.get(left.document.path) ?? Number.POSITIVE_INFINITY
+      const rightContext = contextOrder.get(right.document.path) ?? Number.POSITIVE_INFINITY
       if (leftContext !== rightContext) return leftContext - rightContext
       if (left.score !== right.score) return left.score - right.score
       if (left.document.kind !== right.document.kind) {


### PR DESCRIPTION
## Summary

- Rank the currently active workspace tab's backing page first in the Agent chat `@` mention candidates.
- Use one path resolver for sorting, Current/Attached state, and selectability.
- Prefer exact separator-normalized paths and use case-insensitive fallback only when it is unambiguous.

## Screenshots

Not included. This is an ordering-only change in the existing mention menu and is covered by component regression tests.

## Verification

- [x] Focused unit or component tests
- [x] `pnpm run build:check`
- [ ] `pnpm test:e2e`
- [x] `pnpm test:table:e2e`
- [x] Added or updated a regression test, or explained why one was not needed

Commands run:

- `pnpm exec vitest run --config tooling/vitest.config.ts src/features/agent/lib/documentMentions.spec.ts src/features/agent/components/AgentAiComposer.spec.tsx` — 16/16 passed.
- `pnpm run build:check` — passed.
- `pnpm run lint` — passed.
- `python3 scripts/check-i18n.py` — passed.
- `pnpm test:table:e2e` — 13/13 passed.

The full unit suite was also attempted earlier. It reported 3 unrelated template-image checksum failures because this checkout contains Git LFS pointer text instead of the corresponding binary WebP assets; 3,808 tests passed.

## AI Review

- User-visible behavior: the active tab is first and remains consistently marked Current/Attached; copy is unchanged.
- Platform coverage: slash and backslash path representations are handled; exact paths win on case-sensitive filesystems, with unambiguous case-folded fallback.
- Runtime boundary: no public runtime contracts, mocks, API behavior, or private runtime details changed.
- Performance and accessibility: existing menu roles and keyboard behavior are preserved. Path resolution is limited to the in-memory mention candidate set.
- Repository policy: English-only source/tests, Kition branding, and portable paths are preserved.
- Independent AI code review found no remaining Critical, Important, or Minor issues and assessed the change ready to merge.

## Security Review

The change compares local workspace path strings only. It adds no file I/O, credentials, network requests, IPC, external URLs, dependency changes, or destructive actions. Ambiguous case-folded paths are intentionally not treated as the active file.

## Release Boundary

- [x] No credentials, private runtime binaries, host-specific paths, generated local data, or private implementation details are included.
- [x] Public contracts or mocks were updated before relying on new runtime behavior. No runtime behavior is introduced by this PR.
- [x] This pull request does not include an unrequested version bump, tag, or release action.
